### PR TITLE
TEST/APPS: Fix UCP request leak in case of unsuccessful ucp_stream_send_nb

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -594,6 +594,8 @@ bool UcxConnection::connect_common(ucp_ep_params_t& ep_params)
                                     stream_send_callback, 0);
     if (!_context.wait_completion(sreq, 10)) {
         UCX_CONN_LOG << "failed to send remote connection id";
+        ucp_request_cancel(_context.worker(), rreq);
+        ucp_request_release(rreq);
         ep_close(UCP_EP_CLOSE_MODE_FORCE);
         return false;
     }


### PR DESCRIPTION
```
$ ./test/apps/iodemo/.libs/io_demo -d 32768 2.1.4.3 -c 100 -t 2 -w 64 -i 100000
$ ./test/apps/iodemo/.libs/io_demo -d 65536
```
after this clients reports leak of UCP requests (== # of unsuccessful connection attempts):
```
+ ./test/apps/iodemo/.libs/io_demo -d 32768 2.1.4.3 -c 100 -t 2 -w 64 -i 100000
[UCX] created context 0x616000000c80
[UCX] created worker 0x631000014800
[UCX-connection #1 0.0.0.0:0] created new connection, total: 1
[UCX-connection #1 2.1.4.3:1337] created endpoint 0x7fa8e91a0000, exchanging connection id
[UCX-connection #1 2.1.4.3:1337] detected error: Operation rejected by remote peer
[UCX-connection #1 2.1.4.3:1337] failed to send remote connection id
[UCX-connection #1 2.1.4.3:1337] closing ep 0x7fa8e91a0000 mode force
[UCX-connection #1 2.1.4.3:1337] released
[DEMO] retry 1/100 in 2 seconds
[UCX-connection #2 0.0.0.0:0] created new connection, total: 1
[UCX-connection #2 2.1.4.3:1337] created endpoint 0x7fa8e91a0000, exchanging connection id
[UCX-connection #2 2.1.4.3:1337] detected error: Operation rejected by remote peer
[UCX-connection #2 2.1.4.3:1337] failed to send remote connection id
[UCX-connection #2 2.1.4.3:1337] closing ep 0x7fa8e91a0000 mode force
[UCX-connection #2 2.1.4.3:1337] released
[DEMO] retry 2/100 in 2 seconds
[UCX-connection #3 0.0.0.0:0] created new connection, total: 1
[UCX-connection #3 2.1.4.3:1337] created endpoint 0x7fa8e91a0000, exchanging connection id
[UCX-connection #3 2.1.4.3:1337] detected error: Operation rejected by remote peer
[UCX-connection #3 2.1.4.3:1337] failed to send remote connection id
[UCX-connection #3 2.1.4.3:1337] closing ep 0x7fa8e91a0000 mode force
[UCX-connection #3 2.1.4.3:1337] released
[DEMO] retry 3/100 in 2 seconds
[UCX-connection #4 0.0.0.0:0] created new connection, total: 1
[UCX-connection #4 2.1.4.3:1337] created endpoint 0x7fa8e91a0000, exchanging connection id
[UCX-connection #4 2.1.4.3:1337] remote id is 1
25750 iterations of write, throughput: 804.681 MB/s
25850 iterations of write, throughput: 807.681 MB/s
25820 iterations of write, throughput: 806.761 MB/s
22580 iterations of write, throughput: 806.693 MB/s
[UCX-connection #4 2.1.4.3:1337] closing ep 0x7fa8e91a0000 mode force
[UCX-connection #4 2.1.4.3:1337] released
[1588019417.113365] [sputnik4:27966:0]          mpool.c:42   UCX  WARN  object 0x62e000009f40 was not returned to mpool ucp_requests
[1588019417.113387] [sputnik4:27966:0]          mpool.c:42   UCX  WARN  object 0x62e00000a080 was not returned to mpool ucp_requests
[1588019417.113395] [sputnik4:27966:0]          mpool.c:42   UCX  WARN  object 0x62e00000a1c0 was not returned to mpool ucp_requests
```