### PR TITLE
UCT/RC: RDMA_READ FC by number of bytes

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -72,7 +72,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -496,7 +497,7 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
     uct_dc_mlx5_iface_bcopy_post(iface, ep, MLX5_OPCODE_RDMA_READ, length,
                                  remote_addr, rkey, desc, 0, 0, desc + 1, NULL);
 
-    UCT_RC_RDMA_READ_POSTED(&iface->super.super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super.super, length);
     UCT_TL_EP_STAT_OP(&ep->super, GET, BCOPY, length);
 
     return UCS_INPROGRESS;
@@ -521,7 +522,7 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                  0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
                                  uct_rc_ep_get_zcopy_completion_handler, comp, 0);
 
-    UCT_RC_RDMA_READ_POSTED(&iface->super.super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super.super, uct_iov_total_length(iov, iovcnt));
     UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, uct_iov_total_length(iov, iovcnt));
 
     return UCS_INPROGRESS;

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -49,6 +49,7 @@ uct_dc_mlx5_iface_bcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
 static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                              unsigned opcode, const uct_iov_t *iov, size_t iovcnt,
+                             size_t iov_total_length,
                              /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
                              /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
                              /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
@@ -72,8 +73,7 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
-                              uct_iov_total_length(iov, iovcnt));
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov_total_length);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -370,7 +370,7 @@ ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
                                UCT_IB_MLX5_AV_FULL_SIZE);
     UCT_DC_CHECK_RES_AND_FC(iface, ep);
 
-    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, iov, iovcnt,
+    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul,
                                  id, header, header_length, 0, 0, 0ul, 0, 0,
                                  uct_rc_ep_send_op_completion_handler,
                                  comp, MLX5_WQE_CTRL_SOLICITED);
@@ -469,7 +469,7 @@ ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     UCT_DC_MLX5_CHECK_RMA_RES(iface, ep);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt,
-                                 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
+                                 0ul, 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
                                  uct_rc_ep_send_op_completion_handler, comp, 0);
 
     UCT_TL_EP_STAT_OP(&ep->super, PUT, ZCOPY,
@@ -510,20 +510,22 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
+    size_t total_length        = uct_iov_total_length(iov, iovcnt);
 
     UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE),
                        "uct_dc_mlx5_ep_get_zcopy");
-    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
+    UCT_CHECK_LENGTH(total_length,
                      iface->super.super.super.config.max_inl_resp + 1,
                      iface->super.super.config.max_get_zcopy, "get_zcopy");
     UCT_DC_MLX5_CHECK_RMA_RES(iface, ep);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
-                                 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
+                                 total_length, 0, NULL, 0, remote_addr, rkey,
+                                 0ul, 0, 0,
                                  uct_rc_ep_get_zcopy_completion_handler, comp, 0);
 
-    UCT_RC_RDMA_READ_POSTED(&iface->super.super, uct_iov_total_length(iov, iovcnt));
-    UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, uct_iov_total_length(iov, iovcnt));
+    UCT_RC_RDMA_READ_POSTED(&iface->super.super, total_length);
+    UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, total_length);
 
     return UCS_INPROGRESS;
 }
@@ -699,7 +701,7 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND, _IMM);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
-                                 iov, iovcnt, 0, "", 0, 0, 0, tag, app_ctx,
+                                 iov, iovcnt, 0ul, 0, "", 0, 0, 0, tag, app_ctx,
                                  ib_imm, uct_rc_ep_send_op_completion_handler,
                                  comp, MLX5_WQE_CTRL_SOLICITED);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -50,8 +50,8 @@ uct_rc_mlx5_txqp_bcopy_post(uct_rc_mlx5_iface_common_t *iface,
  * Adds user completion to the callback queue.
  */
 static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
-                          unsigned opcode, const uct_iov_t *iov, size_t iovcnt,
+uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep, unsigned opcode,
+                          const uct_iov_t *iov, size_t iovcnt, size_t iov_total_length,
                           /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
                           /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
                           /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
@@ -76,8 +76,8 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
-                              uct_iov_total_length(iov, iovcnt));
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov_total_length);
+
     return UCS_INPROGRESS;
 }
 
@@ -216,7 +216,7 @@ ucs_status_t uct_rc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     UCT_RC_CHECK_NUM_RDMA_READ(iface);
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt,
-                                       0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
+                                       0ul, 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
                                        MLX5_WQE_CTRL_CQ_UPDATE,
                                        uct_rc_ep_send_op_completion_handler,
                                        comp);
@@ -252,25 +252,25 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
                                       uint64_t remote_addr, uct_rkey_t rkey,
                                       uct_completion_t *comp)
 {
+    size_t total_length = uct_iov_total_length(iov, iovcnt);
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     ucs_status_t status;
 
     UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(0),
                        "uct_rc_mlx5_ep_get_zcopy");
-    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
+    UCT_CHECK_LENGTH(total_length,
                      iface->super.super.config.max_inl_resp + 1,
                      iface->super.config.max_get_zcopy, "get_zcopy");
     UCT_RC_CHECK_NUM_RDMA_READ(&iface->super);
 
     status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
-                                       0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
-                                       MLX5_WQE_CTRL_CQ_UPDATE,
+                                       total_length, 0, NULL, 0, remote_addr,
+                                       rkey, 0ul, 0, 0, MLX5_WQE_CTRL_CQ_UPDATE,
                                        uct_rc_ep_get_zcopy_completion_handler,
                                        comp);
     if (!UCS_STATUS_IS_ERR(status)) {
-        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
-                          uct_iov_total_length(iov, iovcnt));
-        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
+        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY, total_length);
+        UCT_RC_RDMA_READ_POSTED(&iface->super, total_length);
     }
     return status;
 }
@@ -354,7 +354,7 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
                                iface->super.super.config.seg_size, 0);
     UCT_RC_CHECK_FC(&iface->super, &ep->super, id);
 
-    status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, iov, iovcnt,
+    status = uct_rc_mlx5_ep_zcopy_post(ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul,
                                        id, header, header_length, 0, 0, 0ul, 0, 0,
                                        MLX5_WQE_CTRL_SOLICITED,
                                        uct_rc_ep_send_op_completion_handler,
@@ -803,7 +803,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                       uct_iov_total_length(iov, iovcnt));
 
     return uct_rc_mlx5_ep_zcopy_post(ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
-                                     iov, iovcnt, 0, "", 0, 0, 0,
+                                     iov, iovcnt, 0ul, 0, "", 0, 0, 0,
                                      tag, app_ctx, ib_imm,
                                      MLX5_WQE_CTRL_SOLICITED,
                                      uct_rc_ep_send_op_completion_handler,

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -76,7 +76,8 @@ uct_rc_mlx5_ep_zcopy_post(uct_rc_mlx5_ep_t *ep,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
-                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
     return UCS_INPROGRESS;
 }
 
@@ -243,7 +244,7 @@ ucs_status_t uct_rc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
                                 rkey, MLX5_WQE_CTRL_CQ_UPDATE, 0, desc, desc + 1,
                                 NULL);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
-    UCT_RC_RDMA_READ_POSTED(&iface->super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super, length);
     return UCS_INPROGRESS;
 }
 
@@ -269,7 +270,7 @@ ucs_status_t uct_rc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     if (!UCS_STATUS_IS_ERR(status)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
                           uct_iov_total_length(iov, iovcnt));
-        UCT_RC_RDMA_READ_POSTED(&iface->super);
+        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
     }
     return status;
 }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -167,13 +167,13 @@ uct_rc_op_release_iface_resources(uct_rc_iface_send_op_t *op, int is_get_zcopy)
     uct_rc_iface_t *iface;
 
     if (is_get_zcopy) {
-        ++op->iface->tx.reads_available;
+        op->iface->tx.reads_available += op->length;
         return;
     }
 
     desc  = ucs_derived_of(op, uct_rc_iface_send_desc_t);
     iface = ucs_container_of(ucs_mpool_obj_owner(desc), uct_rc_iface_t, tx.mp);
-    ++iface->tx.reads_available;
+    iface->tx.reads_available += op->length;
 }
 
 void uct_rc_ep_get_bcopy_handler(uct_rc_iface_send_op_t *op, const void *resp)

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -102,7 +102,7 @@ enum {
 #define UCT_RC_RDMA_READ_POSTED(_iface, _length) \
     { \
         ucs_assert((_iface)->tx.reads_available > 0); \
-        (_iface)->tx.reads_available -= _length; \
+        (_iface)->tx.reads_available -= (_length); \
     }
 
 #define UCT_RC_CHECK_RES(_iface, _ep) \

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -93,16 +93,16 @@ enum {
     }
 
 #define UCT_RC_CHECK_NUM_RDMA_READ(_iface) \
-    if (ucs_unlikely((_iface)->tx.reads_available == 0)) { \
+    if (ucs_unlikely((_iface)->tx.reads_available <= 0)) { \
         UCS_STATS_UPDATE_COUNTER((_iface)->stats, \
                                  UCT_RC_IFACE_STAT_NO_READS, 1); \
         return UCS_ERR_NO_RESOURCE; \
     }
 
-#define UCT_RC_RDMA_READ_POSTED(_iface) \
+#define UCT_RC_RDMA_READ_POSTED(_iface, _length) \
     { \
         ucs_assert((_iface)->tx.reads_available > 0); \
-        --(_iface)->tx.reads_available; \
+        (_iface)->tx.reads_available -= _length; \
     }
 
 #define UCT_RC_CHECK_RES(_iface, _ep) \
@@ -330,7 +330,7 @@ uct_rc_txqp_add_send_op_sn(uct_rc_txqp_t *txqp, uct_rc_iface_send_op_t *op, uint
 static UCS_F_ALWAYS_INLINE void
 uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
                           uct_rc_send_handler_t handler, uct_completion_t *comp,
-                          uint16_t sn, uint16_t flags)
+                          uint16_t sn, uint16_t flags, size_t length)
 {
     uct_rc_iface_send_op_t *op;
 
@@ -342,6 +342,7 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
     op->handler   = handler;
     op->user_comp = comp;
     op->flags    |= flags;
+    op->length    = length;
     uct_rc_txqp_add_send_op_sn(txqp, op, sn);
 }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -86,13 +86,17 @@ ucs_config_field_t uct_rc_iface_common_config_table[] = {
    ucs_offsetof(uct_rc_iface_common_config_t, fence_mode),
                 UCS_CONFIG_TYPE_ENUM(uct_rc_fence_mode_values)},
 
-  {"TX_NUM_GET_OPS", "inf",
-   "Maximal number of simultaneous get/RDMA_READ operations.",
-   ucs_offsetof(uct_rc_iface_common_config_t, tx.max_get_ops), UCS_CONFIG_TYPE_UINT},
+  {"TX_NUM_GET_OPS", "",
+   "The configuration parameter replaced by UCX_RC_TX_NUM_GET_BYTES.",
+   UCS_CONFIG_DEPRECATED_FIELD_OFFSET, UCS_CONFIG_TYPE_DEPRECATED},
 
   {"MAX_GET_ZCOPY", "auto",
    "Maximal size of get operation with zcopy protocol.",
    ucs_offsetof(uct_rc_iface_common_config_t, tx.max_get_zcopy), UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"TX_NUM_GET_BYTES", "inf",
+   "Maximal number of bytes simultaneously transferred by get/RDMA_READ operations.",
+   ucs_offsetof(uct_rc_iface_common_config_t, tx.max_get_bytes), UCS_CONFIG_TYPE_MEMUNITS},
 
   {NULL}
 };
@@ -550,7 +554,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
                               &config->super, init_attr);
 
     self->tx.cq_available           = init_attr->tx_cq_len - 1;
-    self->tx.reads_available        = config->tx.max_get_ops;
     self->rx.srq.available          = 0;
     self->rx.srq.quota              = 0;
     self->config.tx_qp_len          = config->super.tx.queue_len;
@@ -584,6 +587,13 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
                  uct_ib_device_name(dev), self->super.config.port_num,
                  max_ib_msg_size);
         self->config.max_get_zcopy = max_ib_msg_size;
+    }
+
+    if ((config->tx.max_get_bytes == UCS_MEMUNITS_INF) ||
+       (config->tx.max_get_bytes == UCS_MEMUNITS_AUTO)) {
+        self->tx.reads_available = SSIZE_MAX;
+    } else {
+        self->tx.reads_available = config->tx.max_get_bytes;
     }
 
     uct_ib_fence_info_init(&self->tx.fi);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -152,8 +152,8 @@ typedef struct uct_rc_iface_common_config {
         unsigned             retry_count;
         double               rnr_timeout;
         unsigned             rnr_retry_count;
-        unsigned             max_get_ops;
         size_t               max_get_zcopy;
+        size_t               max_get_bytes;
     } tx;
 
     struct {
@@ -207,7 +207,7 @@ struct uct_rc_iface {
          * In case of verbs TL we use QWE number, so 1 post always takes 1
          * credit */
         signed                  cq_available;
-        unsigned                reads_available;
+        ssize_t                 reads_available;
         uct_rc_iface_send_op_t  *free_ops; /* stack of free send operations */
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
@@ -442,7 +442,7 @@ static inline int uct_rc_iface_has_tx_resources(uct_rc_iface_t *iface)
 {
     return uct_rc_iface_have_tx_cqe_avail(iface) &&
            !ucs_mpool_is_empty(&iface->tx.mp) &&
-           (iface->tx.reads_available != 0);
+           (iface->tx.reads_available > 0);
 }
 
 static UCS_F_ALWAYS_INLINE uct_rc_send_handler_t

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -71,7 +71,8 @@ uct_rc_verbs_ep_post_send_desc(uct_rc_verbs_ep_t* ep, struct ibv_send_wr *wr,
 
 static inline ucs_status_t
 uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
-                           size_t iovcnt, uint64_t remote_addr, uct_rkey_t rkey,
+                           size_t iovcnt, size_t iov_total_length,
+                           uint64_t remote_addr, uct_rkey_t rkey,
                            uct_completion_t *comp, uct_rc_send_handler_t handler,
                            int opcode)
 {
@@ -95,7 +96,8 @@ uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_SIGNALED, INT_MAX);
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp,
                               ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
-                              uct_iov_total_length(iov, iovcnt));
+                              iov_total_length);
+
     return UCS_INPROGRESS;
 }
 
@@ -182,8 +184,8 @@ ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, siz
 
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_put_zcopy");
-    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr, rkey, comp,
-                                        uct_rc_ep_send_op_completion_handler,
+    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, 0ul, remote_addr, rkey,
+                                        comp, uct_rc_ep_send_op_completion_handler,
                                         IBV_WR_RDMA_WRITE);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
@@ -223,22 +225,22 @@ ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
     uct_rc_verbs_iface_t  *iface = ucs_derived_of(tl_ep->iface,
                                                   uct_rc_verbs_iface_t);
     uct_rc_verbs_ep_t *ep        = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
+    size_t total_length          = uct_iov_total_length(iov, iovcnt);
     ucs_status_t status;
 
     UCT_CHECK_IOV_SIZE(iovcnt, iface->config.max_send_sge,
                        "uct_rc_verbs_ep_get_zcopy");
-    UCT_CHECK_LENGTH(uct_iov_total_length(iov, iovcnt),
+    UCT_CHECK_LENGTH(total_length,
                      iface->super.super.config.max_inl_resp + 1,
                      iface->super.config.max_get_zcopy, "get_zcopy");
 
-    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, remote_addr,
+    status = uct_rc_verbs_ep_rdma_zcopy(ep, iov, iovcnt, total_length, remote_addr,
                                         rkey, comp,
                                         uct_rc_ep_get_zcopy_completion_handler,
                                         IBV_WR_RDMA_READ);
     if (!UCS_STATUS_IS_ERR(status)) {
-        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
-        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
-                          uct_iov_total_length(iov, iovcnt));
+        UCT_RC_RDMA_READ_POSTED(&iface->super, total_length);
+        UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY, total_length);
     }
     return status;
 }

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -94,7 +94,8 @@ uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
 
     uct_rc_verbs_ep_post_send(iface, ep, &wr, IBV_SEND_SIGNALED, INT_MAX);
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp,
-                              ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY);
+                              ep->txcnt.pi, UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
+                              uct_iov_total_length(iov, iovcnt));
     return UCS_INPROGRESS;
 }
 
@@ -211,7 +212,7 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
 
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SIGNALED, INT_MAX);
-    UCT_RC_RDMA_READ_POSTED(&iface->super);
+    UCT_RC_RDMA_READ_POSTED(&iface->super, length);
     return UCS_INPROGRESS;
 }
 
@@ -235,7 +236,7 @@ ucs_status_t uct_rc_verbs_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                         uct_rc_ep_get_zcopy_completion_handler,
                                         IBV_WR_RDMA_READ);
     if (!UCS_STATUS_IS_ERR(status)) {
-        UCT_RC_RDMA_READ_POSTED(&iface->super);
+        UCT_RC_RDMA_READ_POSTED(&iface->super, uct_iov_total_length(iov, iovcnt));
         UCT_TL_EP_STAT_OP(&ep->super.super, GET, ZCOPY,
                           uct_iov_total_length(iov, iovcnt));
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -140,9 +140,9 @@ UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
 class test_rc_get_limit : public test_rc {
 public:
     test_rc_get_limit() {
-        m_num_get_ops = 8;
-        modify_config("RC_TX_NUM_GET_OPS",
-                      ucs::to_string(m_num_get_ops).c_str());
+        m_num_get_bytes = 8 * UCS_KBYTE + 557; // some non power of 2
+        modify_config("RC_TX_NUM_GET_BYTES",
+                      ucs::to_string(m_num_get_bytes).c_str());
 
         m_max_get_zcopy = 4096;
         modify_config("RC_MAX_GET_ZCOPY",
@@ -175,19 +175,19 @@ public:
     }
 #endif
 
-    unsigned reads_available(entity *e) {
+    ssize_t reads_available(entity *e) {
         return rc_iface(e)->tx.reads_available;
     }
 
     void post_max_reads(entity *e, const mapped_buffer &sendbuf,
                         const mapped_buffer &recvbuf) {
-        ucs_status_t status, status_exp;
-
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
                                 sendbuf.memh(), e->iface_attr().cap.get.max_iov);
 
-        for (unsigned i = 0; i <= m_num_get_ops; ++i) {
-            if (i % 2) {
+        int i = 0;
+        ucs_status_t status;
+        do {
+            if (i++ % 2) {
                 status = uct_ep_get_zcopy(e->ep(0), iov, iovcnt, recvbuf.addr(),
                                           recvbuf.rkey(), &m_comp);
             } else {
@@ -195,12 +195,10 @@ public:
                                           sendbuf.ptr(), sendbuf.length(),
                                           recvbuf.addr(), recvbuf.rkey(), &m_comp);
             }
-            status_exp = (i == m_num_get_ops) ? UCS_ERR_NO_RESOURCE :
-                                                UCS_INPROGRESS;
-            EXPECT_EQ(status_exp, status);
-        }
+       } while (status == UCS_INPROGRESS);
 
-        EXPECT_EQ(0u, reads_available(e));
+       EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+       EXPECT_GE(0u, reads_available(e));
     }
 
     static size_t empty_pack_cb(void *dest, void *arg) {
@@ -208,7 +206,7 @@ public:
     }
 
 protected:
-    unsigned         m_num_get_ops;
+    unsigned         m_num_get_bytes;
     unsigned         m_max_get_zcopy;
     uct_completion_t m_comp;
 };
@@ -234,7 +232,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_ops_limit,
     uct_ep_pending_purge(m_e1->ep(0), NULL, NULL);
 
     flush();
-    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
 }
 
 // Check that get function fails for messages bigger than MAX_GET_ZCOPY value
@@ -254,7 +252,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_size_limit,
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
 
     flush();
-    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
 }
 
 // Check that get size value is trimmed by the actual maximum IB msg size
@@ -376,7 +374,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, check_rma_ops,
     }
 
     flush();
-    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
 }
 
 // Check that outstanding get ops purged gracefully when ep is closed.
@@ -385,15 +383,15 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_zcopy_purge,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
                                  UCT_IFACE_FLAG_GET_BCOPY))
 {
-    mapped_buffer sendbuf(128, 0ul, *m_e1);
-    mapped_buffer recvbuf(128, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, *m_e1);
+    mapped_buffer recvbuf(1024, 0ul, *m_e2);
 
     post_max_reads(m_e1, sendbuf, recvbuf);
 
     scoped_log_handler hide_warn(hide_warns_logger);
     m_e1->destroy_eps();
     flush();
-    EXPECT_EQ(m_num_get_ops, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
 }
 
 UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_get_limit)


### PR DESCRIPTION
RDMA_READ FC by number of bytes.
Some tests failing on this branch with this stack
```
#0  0x00007f927238379d in uct_ib_device_async_event_get_count (dev=0x1df19a8, event_type=IBV_EVENT_QP_LAST_WQE_REACHED, resource_id=51367) at base/ib_device.c:223
#1  0x00007f927239d183 in uct_rc_mlx5_ep_clean_rx_cq_cb (iface=<optimized out>, cqe=<optimized out>, arg=<optimized out>) at rc/accel/rc_mlx5_ep.c:930
#2  0x00007f92723b7dff in uct_rc_mlx5_iface_commom_cq_clean (iface=iface@entry=0x1df4010, dir=dir@entry=UCT_IB_DIR_RX, qp_num=51367, cb=cb@entry=0x7f927239d130 <uct_rc_mlx5_ep_clean_rx_cq_cb>, arg=arg@entry=0x1f342f0)
    at rc/accel/rc_mlx5_common.c:1104
#3  0x00007f927239d1e9 in uct_rc_mlx5_ep_clean_qp (qp=qp@entry=0x1f342f0, txqp=txqp@entry=0x1f34290, txwq=txwq@entry=0x1f342f0, ep=0x1f34280) at rc/accel/rc_mlx5_ep.c:957
#4  0x00007f927239d2c7 in uct_rc_mlx5_ep_t_cleanup (self=0x1f34280) at rc/accel/rc_mlx5_ep.c:980
#5  0x00007f9272d7e02e in ucs_class_call_cleanup_chain (cls=cls@entry=0x7f9272607480 <uct_rc_mlx5_ep_t_class>, obj=obj@entry=0x1f34280, limit=limit@entry=-1) at type/class.c:56
#6  0x00007f92723aef40 in uct_rc_mlx5_ep_t_delete (self=0x1f34280) at rc/accel/rc_mlx5_ep.c:1028
#7  0x0000000000684426 in release (this=0x1f02fd0) at ./common/test_helpers.h:656
#8  reset (this=0x1f02fd0) at ./common/test_helpers.h:595
#9  uct_test::entity::destroy_eps (this=0x1dbdb30) at uct/uct_test.cc:1053
#10 0x000000000068919c in uct_test::cleanup (this=this@entry=0x1daff70) at uct/uct_test.cc:448

```