### PR TITLE
TEST: io_demo - fix segv due to double calling of ucp_cleanup()

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -102,6 +102,7 @@ bool UcxContext::init()
     status = ucp_worker_create(_context, &worker_params, &_worker);
     if (status != UCS_OK) {
         ucp_cleanup(_context);
+        _context = NULL;
         UCX_LOG << "ucp_worker_create() failed: " << ucs_status_string(status);
         return false;
     }


### PR DESCRIPTION
if ucp_worker_create() fails, ucp_cleanup() is called.
in order to prevent the call to this function from the UcxContext
destructor as well, set _context to NULL.