### PR TITLE
Error flow fixes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -730,7 +730,7 @@ void ucp_ep_err_pending_purge(uct_pending_req_t *self, void *arg)
     ucp_request_t *req      = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t  status    = UCS_PTR_STATUS(arg);
 
-    ucp_request_complete_one(req, status);
+    ucp_request_handle_send_error(req, status);
 }
 
 static void ucp_destroyed_ep_pending_purge(uct_pending_req_t *self, void *arg)

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -390,7 +390,7 @@ ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
                                     const ucp_request_send_proto_t *proto);
 
 /* Fast-forward to data end */
-void ucp_request_complete_one(ucp_request_t *req, ucs_status_t status);
+void ucp_request_handle_send_error(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -398,7 +398,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
                                        UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
                                        status);
         if (UCS_STATUS_IS_ERR(status)) {
-            return status;
+            ucp_request_handle_send_error(req, status);
+            return UCS_OK;
         } else {
             if (enable_am_bw) {
                 ucp_send_request_next_am_bw_lane(req, state.offset > 0);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -247,8 +247,8 @@ void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
 
 ucs_status_t uct_rc_ep_fc_grant(uct_pending_req_t *self);
 
-void uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
-                                   int is_log);
+int uct_rc_txqp_purge_outstanding(uct_rc_txqp_t *txqp, ucs_status_t status,
+                                  int is_log);
 
 ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
                              unsigned flags);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -596,6 +596,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
         self->tx.reads_available = config->tx.max_get_bytes;
     }
 
+    self->tx.arb_cbq_id = UCS_CALLBACKQ_ID_NULL;
+
     uct_ib_fence_info_init(&self->tx.fi);
     uct_rc_iface_set_path_mtu(self, config);
     memset(self->eps, 0, sizeof(self->eps));
@@ -710,6 +712,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)
 {
     uct_rc_iface_ops_t *ops = ucs_derived_of(self->super.ops, uct_rc_iface_ops_t);
     unsigned i;
+
+    uct_worker_progress_unregister_safe(&self->super.super.worker->super,
+                                        &self->tx.arb_cbq_id);
 
     /* Release table. TODO release on-demand when removing ep. */
     for (i = 0; i < UCT_RC_QP_TABLE_SIZE; ++i) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -212,6 +212,7 @@ struct uct_rc_iface {
         ucs_arbiter_t           arbiter;
         uct_rc_iface_send_op_t  *ops_buffer;
         uct_ib_fence_info_t     fi;
+        int                     arb_cbq_id; /* callback id of arbiter dispatch */
     } tx;
 
     struct {


### PR DESCRIPTION
* fix error cleanup during pending_purge, rndv send failure, and zcopy send failure
* dispatch arbiter after txqp purge to progress pending operations due to release of iface resources (rdma_read flow control)