### PR TITLE
IODEMO: data integrity check

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -534,7 +534,7 @@ void UcxConnection::common_request_callback(void *request, ucs_status_t status)
 
     assert(!r->completed);
     if (r->callback) {
-        // already processed by send function
+        // already processed by send/recv function
         (*r->callback)(status);
         r->conn->request_completed(r);
         UcxContext::request_release(r);

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -8,6 +8,7 @@
 #define IODEMO_UCX_WRAPPER_H_
 
 #include <ucp/api/ucp.h>
+#include <ucs/algorithm/crc.h>
 #include <deque>
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
Added `-q` option to enable data integrity check

for example 2 server and 2 clients connected to both servers:
```
io_demo -b 512 -i 10000000 -d 512:524288 -w 256 -o read,write -p 10001 -q
io_demo -b 512 -i 10000000 -d 512:524288 -w 256 -o read,write -p 10002 -q
io_demo <server1_addr>:10001 <server2_addr>:10002 -b 256 -i 10000000 -d 512:524288 -w 256 -o read,write -q
io_demo <server1_addr>:10001 <server2_addr>:10002 -b 256 -i 10000000 -d 512:524288 -w 256 -o read,write -q
```
current implementation has a limitation - number of buffers (option **-b**) must be more or equal than window size (option **-w**) * N peers to guarantee that any buffer cannot be reused more than once at the moment