### PR TITLE
TEST/IODEMO: Fix _active_servers management

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -806,9 +806,16 @@ public:
         delete conn;
 
         // Replace in _active_servers by the last element in the vector
-        std::swap(_active_servers[server_info.active_index],
-                  _active_servers.back());
+        size_t active_index = server_info.active_index;
+        std::swap(_active_servers[active_index], _active_servers.back());
         assert(_active_servers.back() == server_index);
+
+        // Swap the active_index field with the "replacement" server_info
+        server_info_t& replacement_server_info =
+                _server_info[_active_servers[active_index]];
+        std::swap(replacement_server_info.active_index, server_info.active_index);
+        assert(server_info.active_index == _active_servers.size() - 1);
+
         _active_servers.pop_back();
         reset_server_info(server_info);
     }


### PR DESCRIPTION
When swapping servers in _active_servers array, need to also update the
active index of the server we swap with.