### PR TITLE
UCT/RC/MLX5: Fix reordering when destroying ep releases resources

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -65,8 +65,6 @@ uct_rc_mlx5_common_free_tx_res(uct_rc_iface_t *rc_iface, uct_ib_mlx5_txwq_t *txw
 
     rc_iface->tx.cq_free += bb_num;
 
-    uct_rc_iface_update_reads(rc_iface);
-
     ucs_assertv(rc_iface->tx.cq_available + bb_num <= rc_iface->config.tx_cq_len,
                 "cq_available=%d tx_cq_len=%d bb_num=%d txwq=%p txqp=%p",
                 rc_iface->tx.cq_available, rc_iface->config.tx_cq_len, bb_num,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -367,11 +367,9 @@ int uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
             if ((op->handler == uct_rc_ep_get_bcopy_handler) ||
                 (op->handler == uct_rc_ep_get_bcopy_handler_no_completion)) {
                 uct_rc_op_release_iface_resources(op, 0);
-                uct_rc_iface_update_reads(iface);
                 iface_resources_released = 1;
             } else if (op->handler == uct_rc_ep_get_zcopy_completion_handler) {
                 uct_rc_op_release_iface_resources(op, 1);
-                uct_rc_iface_update_reads(iface);
                 iface_resources_released = 1;
             }
         }


### PR DESCRIPTION
Destroying an RC endpoint (for example, when using RoCE LAG and other
lane has failed) can release CQ and read resources. Make sure the
resources are not release before arbiter dispatch has a first chance to
use them for pending operations.