### PR TITLE
RC and iodemo fixes

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -34,6 +34,7 @@ typedef struct uct_rc_mlx5_ep {
     uct_ib_mlx5_qp_t         tm_qp;
     uct_rc_mlx5_mp_context_t mp;
     uint16_t                 atomic_mr_offset;
+    uint8_t                  connected;
 } uct_rc_mlx5_ep_t;
 
 typedef struct uct_rc_mlx5_ep_address {

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -553,7 +553,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_rc_iface_ops_t *ops, uct_md_h md,
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, &ops->super, md, worker, params,
                               &config->super, init_attr);
 
-    self->tx.cq_available           = init_attr->tx_cq_len - 1;
+    self->tx.cq_available           = init_attr->tx_cq_len - 2; /* reserve for nop */
     self->tx.cq_free                = 0;
     self->rx.srq.available          = 0;
     self->rx.srq.quota              = 0;

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -671,9 +671,14 @@ public:
         recv_data(conn, *iov, msg->tr.sn, w);
     }
 
+    virtual void dispatch_connection_accepted(UcxConnection* conn) {
+        ++_curr_state.active_conns;
+    }
+
     virtual void dispatch_connection_error(UcxConnection *conn) {
         LOG << "deleting connection with status "
             << ucs_status_string(conn->ucx_status());
+        --_curr_state.active_conns;
         delete conn;
     }
 
@@ -699,24 +704,6 @@ public:
     }
 
 private:
-    virtual bool add_connection(UcxConnection *conn) {
-        bool added = P2pDemoCommon::add_connection(conn);
-        if (added) {
-            ++_curr_state.active_conns;
-        }
-
-        return added;
-    }
-
-    virtual bool remove_connection(UcxConnection *conn) {
-        bool removed = P2pDemoCommon::remove_connection(conn);
-        if (removed) {
-            --_curr_state.active_conns;
-        }
-
-        return removed;
-    }
-
     void save_prev_state() {
         _prev_state = _curr_state;
     }

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -74,8 +74,8 @@ typedef struct {
 template<class T, bool use_offcache = false>
 class MemoryPool {
 public:
-    MemoryPool(size_t buffer_size, size_t offcache = 0) :
-        _num_allocated(0), _buffer_size(buffer_size) {
+    MemoryPool(size_t buffer_size, const std::string& name, size_t offcache = 0) :
+        _num_allocated(0), _buffer_size(buffer_size), _name(name) {
 
         for (size_t i = 0; i < offcache; ++i) {
             _offcache_queue.push(get_free());
@@ -89,8 +89,8 @@ public:
         }
 
         if (_num_allocated != _free_stack.size()) {
-            LOG << "Some items were not freed. Total:" << _num_allocated
-                << ", current:" << _free_stack.size() << ".";
+            LOG << (_num_allocated - _free_stack.size())
+                << " buffers were not released from " << _name;
         }
 
         for (size_t i = 0; i < _free_stack.size(); i++) {
@@ -137,6 +137,7 @@ private:
     std::queue<T*>  _offcache_queue;
     uint32_t        _num_allocated;
     size_t          _buffer_size;
+    std::string     _name;
 };
 
 /**
@@ -438,11 +439,12 @@ protected:
     P2pDemoCommon(const options_t& test_opts) :
         UcxContext(test_opts.iomsg_size),
         _test_opts(test_opts),
-        _io_msg_pool(test_opts.iomsg_size),
-        _send_callback_pool(0),
+        _io_msg_pool(test_opts.iomsg_size, "io messages"),
+        _send_callback_pool(0, "send callbacks"),
         _data_buffers_pool(get_chunk_cnt(test_opts.max_data_size,
-                                         test_opts.chunk_size)),
-        _data_chunks_pool(test_opts.chunk_size, test_opts.num_offcache_buffers) {
+                                         test_opts.chunk_size), "data iovs"),
+        _data_chunks_pool(test_opts.chunk_size, "data chunks",
+                          test_opts.num_offcache_buffers) {
     }
 
     const options_t& opts() const {
@@ -604,7 +606,7 @@ public:
     } state_t;
 
     DemoServer(const options_t& test_opts) :
-        P2pDemoCommon(test_opts), _callback_pool(0) {
+        P2pDemoCommon(test_opts), _callback_pool(0, "callbacks") {
         _curr_state.read_count   = 0;
         _curr_state.write_count  = 0;
         _curr_state.active_conns = 0;
@@ -799,7 +801,7 @@ public:
         P2pDemoCommon(test_opts), _prev_connect_time(0),
         _num_sent(0), _num_completed(0),
         _status(OK), _start_time(get_time()),
-        _retry(0), _read_callback_pool(opts().iomsg_size) {
+        _retry(0), _read_callback_pool(opts().iomsg_size, "read callbacks") {
     }
 
     typedef enum {
@@ -914,12 +916,14 @@ public:
         size_t server_index        = get_server_index(conn);
         server_info_t& server_info = _server_info[server_index];
 
-        // Don't wait from completions on this connection
-        _num_sent -= get_num_uncompleted(server_index);
-
         // Remove connection pointer
         _server_index_lookup.erase(conn);
+
+        // Destroying the connection will complete its outstanding operations
         delete conn;
+
+        // Don't wait for any more completions on this connection
+        _num_sent -= get_num_uncompleted(server_index);
 
         // Replace in _active_servers by the last element in the vector
         size_t active_index = server_info.active_index;

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -94,9 +94,8 @@ protected:
     // Called when there is a fatal failure on the connection
     virtual void dispatch_connection_error(UcxConnection* conn) = 0;
 
-    virtual bool add_connection(UcxConnection *conn);
-
-    virtual bool remove_connection(UcxConnection *conn);
+    // Called when new server connection is accepted
+    virtual void dispatch_connection_accepted(UcxConnection* conn);
 
 private:
     typedef enum {
@@ -137,6 +136,10 @@ private:
                                   double timeout = 1e6);
 
     void recv_io_message();
+
+    void add_connection(UcxConnection *conn);
+
+    void remove_connection(UcxConnection *conn);
 
     void handle_connection_error(UcxConnection *conn);
 


### PR DESCRIPTION
- Reserve 1 CQ credit for qp-flush NOP, to avoid disabling CQ moderation
- Fix keepalive on DevX
- Fix memory leak in IO demo
- Simplify active connection counting