### PR TITLE
RC: Fixes for recent MTT failures

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -83,10 +83,13 @@ static void
 uct_rc_mlx5_iface_common_send_keepalive(uct_rc_mlx5_iface_common_t *iface)
 {
      uct_rc_mlx5_ep_t *ep;
+
+     ucs_spin_lock(&iface->super.ep_list_lock);
      ucs_list_for_each(ep, &iface->super.ep_list, super.list) {
          ucs_trace("send keepalive grant on ep %p", ep);
          uct_rc_ep_fc_send_grant(&ep->super);
      }
+     ucs_spin_unlock(&iface->super.ep_list_lock);
 
      uct_rc_mlx5_iface_print(iface, "keepalive");
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -886,6 +886,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_ep_t, const uct_ep_params_t *params)
 
     uct_rc_mlx5_iface_print(iface, "ep_create");
 
+    self->connected = 0;
+
     /* Need to create QP before super constructor to get QP number */
     uct_rc_mlx5_iface_fill_attr(iface, &attr, iface->super.config.tx_qp_len,
                                 &iface->rx.srq);
@@ -927,7 +929,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_ep_t, const uct_ep_params_t *params)
 
     self->tx.wq.bb_max = ucs_min(self->tx.wq.bb_max, iface->tx.bb_max);
     self->mp.free      = 1;
-    self->connected    = 0;
 
     uct_rc_txqp_available_set(&self->super.txqp, self->tx.wq.bb_max);
     return UCS_OK;

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -117,7 +117,10 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
 
     ucs_arbiter_group_init(&self->arb_group);
 
+    ucs_spin_lock(&iface->ep_list_lock);
     ucs_list_add_head(&iface->ep_list, &self->list);
+    ucs_spin_unlock(&iface->ep_list_lock);
+
     ucs_debug("created rc ep %p", self);
 
     return UCS_OK;
@@ -133,7 +136,10 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_ep_t)
                                            uct_rc_iface_t);
     ucs_debug("destroy rc ep %p", self);
 
+    ucs_spin_lock(&iface->ep_list_lock);
     ucs_list_del(&self->list);
+    ucs_spin_unlock(&iface->ep_list_lock);
+
     uct_rc_ep_pending_purge(&self->super.super, NULL, NULL);
     uct_rc_fc_cleanup(&self->fc);
     uct_rc_txqp_cleanup(iface, &self->txqp);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -267,6 +267,7 @@ struct uct_rc_iface {
 
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
     ucs_list_link_t          ep_list;
+    ucs_spinlock_t           ep_list_lock;
 
     /* Progress function (either regular or TM aware) */
     ucs_callback_t           progress;


### PR DESCRIPTION
- UCT/RC/MLX5: Fix CQ assertion to consider multiple BBs per WQE: fixes "Assertion `uct_rc_mlx5_common_iface_cq_available_total(iface) >= 0' failed"
- UCT/RC: Initialize ep->connected=0 before keepalive could run - fixes "Assertion `iface->tx.in_pending || ucs_arbiter_group_is_empty(&ep->arb_group)' failed" from sending initial conn_id
- UCT/RC: Protect rc_iface->ep_list with a spinlock  - fix potential race condition