### PR TITLE
UCM/BISTRO: Use relative jump instead of absolute jump

### DIFF
--- a/src/ucm/bistro/bistro_aarch64.c
+++ b/src/ucm/bistro/bistro_aarch64.c
@@ -75,7 +75,7 @@ ucs_status_t ucm_bistro_patch(const char *symbol, void *hook,
 
     UCM_LOOKUP_SYMBOL(func, symbol);
 
-    status = ucm_bistro_create_restore_point(func, rp);
+    status = ucm_bistro_create_restore_point(func, sizeof(patch), rp);
     if (UCS_STATUS_IS_ERR(status)) {
         return status;
     }

--- a/src/ucm/bistro/bistro_int.h
+++ b/src/ucm/bistro/bistro_int.h
@@ -30,7 +30,8 @@
 
 ucs_status_t ucm_bistro_apply_patch(void *dst, void *patch, size_t len);
 
-ucs_status_t ucm_bistro_create_restore_point(void *addr, ucm_bistro_restore_point_t **rp);
+ucs_status_t ucm_bistro_create_restore_point(void *addr, size_t len,
+                                             ucm_bistro_restore_point_t **rp);
 
 static inline void *ucm_bistro_lookup(const char *symbol)
 {

--- a/src/ucm/bistro/bistro_x86_64.h
+++ b/src/ucm/bistro/bistro_x86_64.h
@@ -16,11 +16,20 @@
 #define UCM_BISTRO_PROLOGUE
 #define UCM_BISTRO_EPILOGUE
 
-typedef struct ucm_bistro_patch {
+/* Patch by jumping to absolute address loaded from register */
+typedef struct ucm_bistro_jmp_r11_patch {
     uint8_t mov_r11[2];  /* mov %r11, addr */
     void    *ptr;
     uint8_t jmp_r11[3];  /* jmp r11        */
-} UCS_S_PACKED ucm_bistro_patch_t;
+} UCS_S_PACKED ucm_bistro_jmp_r11_patch_t;
+
+
+/* Patch by jumping to relative address by immediate displacement */
+typedef struct ucm_bistro_jmp_near_patch {
+    uint8_t jmp_rel; /* opcode:  JMP rel32          */
+    int32_t disp;    /* operand: jump displacement */
+} UCS_S_PACKED ucm_bistro_jmp_near_patch_t;
+
 
 /**
  * Set library function call hook using Binary Instrumentation


### PR DESCRIPTION
When patching glibc() functions for memory hooks, try to use relative
jump instruction if the hook is within 32 bit offset of the original
function. This way the patch can be 5 bytes instead of 13 bytes, and
avoid race with another thread executing the patched function.