### PR TITLE
UCT: Allow an rdmacm_id to reuse an already in use address.

### DIFF
--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -16,6 +16,10 @@
 
 
 ucs_config_field_t uct_cm_config_table[] = {
+  {"ALLOW_ADDR_INUSE", "no",
+   "Allow using an address that is already in use.",
+   ucs_offsetof(uct_cm_config_t, allow_addr_inuse), UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 
@@ -213,7 +217,8 @@ static ucs_stats_class_t uct_cm_stats_class = {
 #endif
 
 UCS_CLASS_INIT_FUNC(uct_cm_t, uct_cm_ops_t* ops, uct_iface_ops_t* iface_ops,
-                    uct_worker_h worker, uct_component_h component)
+                    uct_worker_h worker, uct_component_h component,
+                    const uct_cm_config_t* config)
 {
     self->ops                     = ops;
     self->component               = component;
@@ -233,6 +238,8 @@ UCS_CLASS_INIT_FUNC(uct_cm_t, uct_cm_ops_t* ops, uct_iface_ops_t* iface_ops,
     self->iface.prog.refcount     = 0;
     self->iface.progress_flags    = 0;
 
+    self->config.allow_addr_inuse = config->allow_addr_inuse;
+
     return UCS_STATS_NODE_ALLOC(&self->iface.stats, &uct_cm_stats_class,
                                 ucs_stats_get_root(), "%s-%p", "iface",
                                 self->iface);
@@ -245,5 +252,5 @@ UCS_CLASS_CLEANUP_FUNC(uct_cm_t)
 
 UCS_CLASS_DEFINE(uct_cm_t, void);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_cm_t, void, uct_cm_ops_t*, uct_iface_ops_t*,
-                          uct_worker_h, uct_component_h);
+                          uct_worker_h, uct_component_h, const uct_cm_config_t*);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_cm_t, void);

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -20,8 +20,7 @@ UCS_CLASS_DECLARE(uct_listener_t, uct_cm_h);
  * Specific CMs extend this structure.
  */
 struct uct_cm_config {
-    /* C standard prohibits empty structures */
-    char  __dummy;
+    int allow_addr_inuse;
 };
 
 /**
@@ -47,6 +46,10 @@ struct uct_cm {
     uct_cm_ops_t     *ops;
     uct_component_h  component;
     uct_base_iface_t iface;
+
+    struct {
+        int          allow_addr_inuse;
+    } config;
 };
 
 
@@ -88,7 +91,7 @@ UCS_CLASS_DECLARE_DELETE_FUNC(uct_cm_base_ep_t, uct_base_ep_t);
 extern ucs_config_field_t uct_cm_config_table[];
 
 UCS_CLASS_DECLARE(uct_cm_t, uct_cm_ops_t*, uct_iface_ops_t*, uct_worker_h,
-                  uct_component_h);
+                  uct_component_h, const uct_cm_config_t*);
 
 ucs_status_t uct_cm_check_ep_params(const uct_ep_params_t *params);
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -544,7 +544,8 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
     ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_cm_t, &uct_rdmacm_cm_ops,
-                              &uct_rdmacm_cm_iface_ops, worker, component);
+                              &uct_rdmacm_cm_iface_ops, worker, component,
+                              config);
 
     self->ev_ch  = rdma_create_event_channel();
     if (self->ev_ch == NULL) {

--- a/src/uct/ib/rdmacm/rdmacm_listener.c
+++ b/src/uct/ib/rdmacm/rdmacm_listener.c
@@ -16,9 +16,10 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_listener_t, uct_cm_h cm,
                     const uct_listener_params_t *params)
 {
     uct_rdmacm_cm_t *rdmacm_cm  = ucs_derived_of(cm, uct_rdmacm_cm_t);
+    int id_reuse_optval         = 1;
+    int backlog;
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     ucs_status_t status;
-    int backlog;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_listener_t, cm);
 
@@ -30,6 +31,15 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_listener_t, uct_cm_h cm,
         ucs_error("rdma_create_id() failed: %m");
         status = UCS_ERR_IO_ERROR;
         goto err;
+    }
+
+    if (rdmacm_cm->super.config.allow_addr_inuse) {
+        if (rdma_set_option(self->id, RDMA_OPTION_ID, RDMA_OPTION_ID_REUSEADDR,
+                            &id_reuse_optval, sizeof(id_reuse_optval))) {
+            ucs_error("rdma_set_option() failed: %m");
+            status = UCS_ERR_IO_ERROR;
+            goto err_destroy_id;
+        }
     }
 
     if (rdma_bind_addr(self->id, (struct sockaddr *)saddr)) {

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -15,7 +15,7 @@
 
 
 ucs_config_field_t uct_tcp_sockcm_config_table[] = {
-  {"", "", NULL,
+  {"TCP_", "", NULL,
    ucs_offsetof(uct_tcp_sockcm_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_cm_config_table)},
 
   {"PRIV_DATA_LEN", "2048",
@@ -154,7 +154,8 @@ UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,
                                                         uct_tcp_sockcm_config_t);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_cm_t, &uct_tcp_sockcm_ops,
-                              &uct_tcp_sockcm_iface_ops, worker, component);
+                              &uct_tcp_sockcm_iface_ops, worker, component,
+                              config);
 
     self->priv_data_len = cm_config->priv_data_len -
                           sizeof(uct_tcp_sockcm_priv_data_hdr_t);


### PR DESCRIPTION
using RDMA_OPTION_ID_REUSEADDR - 
https://patchwork.kernel.org/project/linux-rdma/patch/CF9C39F99A89134C9CF9C4CCB68B8DDF25DCC49B2C@orsmsx501.amr.corp.intel.com/

to set:
UCX_RDMACM_ALLOW_ADDR_INUSE=y

@yosefe please review.