### PR TITLE
UCS/LOG: if user set UCX_LOG_LEVEL=DEBUG, print unsupport warning

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -330,6 +330,9 @@ void ucs_log_init()
          ucs_open_output_stream(ucs_global_opts.log_file, UCS_LOG_LEVEL_FATAL,
                                 &ucs_log_file, &ucs_log_file_close, &next_token);
     }
+    if (ucs_global_opts.log_component.log_level > UCS_MAX_LOG_LEVEL) {
+        ucs_warn("UCX log level DEBUG is not supported, highest supported level is INFO");
+    }
 }
 
 void ucs_log_cleanup()


### PR DESCRIPTION
## What
if user set UCX_LOG_LEVEL=DEBUG, print unsupport warning

## Why
when build release, UCS_MAX_LOG_LEVEL=UCS_LOG_LEVEL_INFO. if user set UCX_LOG_LEVEL=debug, it should not output debug information. so output a warn to remind user.

## How