### PR TITLE
UCS/RCACHE: add UCX_RCACHE_MERGE_ADJACENT=[y/n] to merge adjacent region of rcache

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -491,7 +491,11 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
 
     ucs_rcache_check_inv_queue(rcache);
 
-    ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list);
+    if (rcache->params.merge_adjacent) {
+        ucs_rcache_find_regions(rcache, *start - 1, *end + 1, &region_list);
+    } else {
+        ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list);
+    }
 
     /* TODO check if any of the regions is locked */
 

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -115,6 +115,7 @@ struct ucs_rcache_params {
                                                      be passed to mem_reg/mem_dereg */
     unsigned long          max_regions;         /**< Maximal number of regions */
     size_t                 max_size;            /**< Maximal total size of regions */
+    int                    merge_adjacent;      /**< merge adjacent region */
 };
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -48,6 +48,10 @@ ucs_config_field_t uct_md_config_rcache_table[] = {
      "Maximal total size of registration cache regions",
      ucs_offsetof(uct_md_rcache_config_t, max_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+    {"RCACHE_MERGE_ADJACENT", "n", "if yes, merge adjacent regions of rcache, "
+                                   "otherwise would only merge regions with intersection",
+            ucs_offsetof(uct_md_rcache_config_t, merge_adjacent), UCS_CONFIG_TYPE_BOOL},
+
     {NULL}
 };
 
@@ -452,4 +456,5 @@ void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
     rcache_params->ucm_event_priority = rcache_config->event_prio;
     rcache_params->max_regions        = rcache_config->max_regions;
     rcache_params->max_size           = rcache_config->max_size;
+    rcache_params->merge_adjacent     = rcache_config->merge_adjacent;
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -19,11 +19,12 @@
 
 
 typedef struct uct_md_rcache_config {
-    size_t               alignment;    /**< Force address alignment */
-    unsigned             event_prio;   /**< Memory events priority */
-    double               overhead;     /**< Lookup overhead estimation */
-    unsigned long        max_regions;  /**< Maximal number of rcache regions */
-    size_t               max_size;     /**< Maximal size of mapped memory */
+    size_t               alignment;       /**< Force address alignment */
+    unsigned             event_prio;      /**< Memory events priority */
+    double               overhead;        /**< Lookup overhead estimation */
+    unsigned long        max_regions;     /**< Maximal number of rcache regions */
+    size_t               max_size;        /**< Maximal size of mapped memory */
+    int                  merge_adjacent;  /**< merge adjacent region */
 } uct_md_rcache_config_t;
 
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -269,6 +269,7 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     rcache_params.context            = rmem;
     rcache_params.max_regions        = ULONG_MAX;
     rcache_params.max_size           = SIZE_MAX;
+    rcache_params.merge_adjacent     = 0;
 
     status = ucs_rcache_create(&rcache_params, "xpmem_remote_mem",
                                ucs_stats_get_root(), &rmem->rcache);


### PR DESCRIPTION
## What
add UCX_RCACHE_MERGE_ADJACENT=[y/n] to merge adjacent region of rcache

## Why
if user send many contiguous memory, now ucx will register once for each. we need merge adjacent region to reduce register times.

## How
in rcache, the memory region is [start, end), so if we use [start-1, end+1], the adjacent region will intersect.
