### PR TITLE
UCS/OPTS: Fix variable name

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -101,7 +101,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
 #if ENABLE_DEBUG_DATA
   "bt,freeze",
 #else
-  "none",
+  "",
 #endif
   "Error handling mode. A combination of: 'bt' (print backtrace),\n"
   "'freeze' (freeze and wait for a debugger), 'debug' (attach debugger)",


### PR DESCRIPTION
Wrong name added by 3c14722f55fad15f3f05285f182e6725ef3449f7