### PR TITLE
TEST/IODEMO: Print thread id in the log instead of process id.

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -61,7 +61,7 @@ UcxLog::UcxLog(const char* prefix, bool enable)
     }
 
     size_t str_len = strlen(str);
-    snprintf(str + str_len, sizeof(str) - str_len, "%d] ", getpid());
+    snprintf(str + str_len, sizeof(str) - str_len, "%d] ", ucs_get_tid());
 
     _ss = new std::stringstream();
     (*_ss) << str << prefix << " ";

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <ucs/datastruct/list.h>
+#include <ucs/sys/sys.h>
 
 #define MAX_LOG_PREFIX_SIZE   64
 


### PR DESCRIPTION
@yosefe please review.