### PR TITLE
UCT/IB/RCACHE: Clean invalidated regions during progress

### DIFF
--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -7,7 +7,11 @@
 #ifndef UCS_REG_CACHE_INT_H_
 #define UCS_REG_CACHE_INT_H_
 
+#include "rcache.h"
+
 #include <ucs/datastruct/list.h>
+#include <ucs/datastruct/queue.h>
+#include <ucs/stats/stats.h>
 #include <ucs/type/spinlock.h>
 
 
@@ -60,5 +64,17 @@ struct ucs_rcache {
 
     UCS_STATS_NODE_DECLARE(stats)
 };
+
+
+void ucs_rcache_check_inv_queue_slow(ucs_rcache_t *rcache);
+
+
+static UCS_F_ALWAYS_INLINE void
+ucs_rcache_check_inv_queue_fast(ucs_rcache_t *rcache)
+{
+    if (ucs_unlikely(!ucs_queue_is_empty(&rcache->inv_q))) {
+        ucs_rcache_check_inv_queue_slow(rcache);
+    }
+}
 
 #endif

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -15,6 +15,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/config/parser.h>
+#include <ucs/memory/rcache_int.h>
 #include <string.h>
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -417,4 +417,13 @@ ucs_status_t
 uct_ib_md_handle_mr_list_multithreaded(uct_ib_md_t *md, void *address,
                                        size_t length, uint64_t access,
                                        size_t chunk, struct ibv_mr **mrs);
+
+static UCS_F_ALWAYS_INLINE void
+uct_ib_md_progress(uct_ib_md_t *md)
+{
+    if (ucs_likely(md->rcache != NULL)){
+        ucs_rcache_check_inv_queue_fast(md->rcache);
+    }
+}
+
 #endif

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -139,7 +139,13 @@ static unsigned uct_rc_verbs_iface_progress(void *arg)
         return count;
     }
 
-    return uct_rc_verbs_iface_poll_tx(iface);
+    count = uct_rc_verbs_iface_poll_tx(iface);
+    if (count > 0) {
+        return count;
+    }
+
+    uct_ib_md_progress(uct_ib_iface_md(&iface->super.super));
+    return 0;
 }
 
 static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -847,6 +847,8 @@ static void uct_ud_iface_timer(int timer_id, void *arg)
     ucs_twheel_sweep(&iface->async.slow_timer, now);
     uct_ud_iface_async_progress(iface);
     uct_ud_leave(iface);
+
+    uct_ib_md_progress(uct_ib_iface_md(&iface->super));
 }
 
 void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc)


### PR DESCRIPTION
Fixes https://redmine.mellanox.com/issues/2436871 (Internal link)

When application is idle and not registering more memory, regions which
were invalidated by memory release hooks may remain in the cache and not
be removed. This patch checks the invalidate queue during transport
progress to cleanup those regions.