### PR TITLE
UCT/IB: Fix out-of-box RoCE LAG on MLNX_OFED 5.x

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1316,14 +1316,6 @@ unsigned uct_ib_device_get_roce_lag_level(uct_ib_device_t *dev, uint8_t port_num
     char ndev_name[IFNAMSIZ];
     unsigned roce_lag_level;
     ucs_status_t status;
-    long lag_enable;
-
-    status = ucs_read_file_number(&lag_enable, 1, UCT_IB_DEVICE_SYSFS_FMT,
-                                  uct_ib_device_name(dev), "roce_lag_enable");
-    if ((status != UCS_OK) || !lag_enable) {
-        ucs_debug("RoCE LAG is disabled on %s", uct_ib_device_name(dev));
-        return 1;
-    }
 
     status = uct_ib_device_get_roce_ndev_name(dev, port_num, gid_index,
                                               ndev_name, sizeof(ndev_name));

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -519,6 +519,7 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             unsigned path_index,
                                             struct ibv_ah_attr *ah_attr)
 {
+    uint16_t udp_sport;
     uint8_t path_bits;
 
     memset(ah_attr, 0, sizeof(*ah_attr));
@@ -528,8 +529,11 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
     ah_attr->grh.traffic_class = iface->config.traffic_class;
 
     if (uct_ib_iface_is_roce(iface)) {
-        ah_attr->dlid          = UCT_IB_ROCE_UDP_SRC_PORT_BASE |
-                                 (iface->config.roce_path_factor * path_index);
+        udp_sport               = iface->config.roce_path_factor * path_index;
+        /* older drivers use dlid for udp.sport, new drivers use flow_label when
+           its nonzero */
+        ah_attr->dlid           = UCT_IB_ROCE_UDP_SRC_PORT_BASE | udp_sport;
+        ah_attr->grh.flow_label = ~udp_sport;
     } else {
         /* TODO iface->path_bits should be removed and replaced by path_index */
         path_bits              = iface->path_bits[path_index %


### PR DESCRIPTION
- Don't read roce_lag_enable from sysfs (it was removed)
- Allow RoCE LAG without DevX by setting flow_label in ah_attr