### PR TITLE
UCT/IB/BASE: use random roce path factor to achieve high reliability.

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -47,6 +47,7 @@
 #define UCT_IB_SITE_LOCAL_MASK            be64toh(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
 #define UCT_IB_DEFAULT_ROCEV2_DSCP        106  /* Default DSCP for RoCE v2 */
 #define UCT_IB_ROCE_UDP_SRC_PORT_BASE     0xC000
+#define UCT_IB_ROCE_MAX_PATH_FACTOR       0x400
 #define UCT_IB_DEVICE_SYSFS_PFX           "/sys/class/infiniband/%s"
 #define UCT_IB_DEVICE_SYSFS_FMT           UCT_IB_DEVICE_SYSFS_PFX "/device/%s"
 #define UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX  UCT_IB_DEVICE_SYSFS_PFX "/ports/%d/gid_attrs"

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -122,6 +122,9 @@ struct uct_ib_iface_config {
     /* Multiplier for RoCE LAG UDP source port calculation */
     unsigned                roce_path_factor;
 
+    /* Enable random path factor for RoCE LAG UDP source port calculation */
+    int                     roce_random_path;
+
     /* Ranges of path bits */
     UCS_CONFIG_ARRAY_FIELD(ucs_range_spec_t, ranges) lid_path_bits;
 
@@ -195,6 +198,7 @@ struct uct_ib_iface {
     uint16_t                  pkey_value;
     uint8_t                   addr_size;
     uct_ib_device_gid_info_t  gid_info;
+    unsigned                  rand_value;
 
     struct {
         unsigned              rx_payload_offset;   /* offset from desc to payload */
@@ -205,6 +209,7 @@ struct uct_ib_iface {
         unsigned              tx_max_poll;
         unsigned              seg_size;
         unsigned              roce_path_factor;
+        uint8_t               roce_random_path;
         uint8_t               max_inl_resp;
         uint8_t               port_num;
         uint8_t               sl;


### PR DESCRIPTION
UCT/IB/BASE: use random roce path factor to achieve high reliability.

When the switches on the current path have problem, the application can disconnect and reconnect again to achieve high reliability. A random roce path factor will be generated to find different sport and use different path.