### PR TITLE
UCP/STREAM: fix a race condition when connecting to sockaddr

### DIFF
--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -93,7 +93,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nb,
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(ep->worker->context, UCP_FEATURE_STREAM,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+    UCS_ASYNC_BLOCK(&ep->worker->async);
 
     ucs_trace_req("stream_send_nb buffer %p count %zu to %s cb %p flags %u",
                   buffer, count, ucp_ep_peer_name(ep), cb, flags);
@@ -135,7 +135,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nb,
                               ucp_ep_config(ep)->stream.proto);
 
 out:
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
+    UCS_ASYNC_UNBLOCK(&ep->worker->async);
     return ret;
 }
 


### PR DESCRIPTION
first trying to send can cause a race condition with wireup if it's called before ucp_cm_client_priv_pack_cb is called on async thread
@yosefe 