### PR TITLE
IODEMO: extend server statistics

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -609,6 +609,44 @@ public:
         long    active_conns;
     } state_t;
 
+    class ConnectionState {
+    public:
+        ConnectionState() {
+            reset();
+        }
+
+        void reset() {
+            _read_req_bytes  = 0;
+            _read_req_count  = 0;
+            _write_req_bytes = 0;
+            _write_req_count = 0;
+        }
+
+        long get_total_count() const {
+            return _read_req_count + _write_req_count;
+        }
+
+        long get_total_bytes() const {
+            return _read_req_bytes + _write_req_bytes;
+        }
+
+        void read_started(size_t bytes) {
+            _read_req_bytes += bytes;
+            ++_read_req_count;
+        }
+
+        void write_started(size_t bytes) {
+            _write_req_bytes += bytes;
+            ++_write_req_count;
+        }
+
+    private:
+        long _read_req_bytes;
+        long _read_req_count;
+        long _write_req_bytes;
+        long _write_req_count;
+    };
+
     DemoServer(const options_t& test_opts) :
         P2pDemoCommon(test_opts), _callback_pool(0, "callbacks") {
         _curr_state.read_count   = 0;
@@ -680,6 +718,10 @@ public:
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
         cb->init(iov, &_curr_state.read_count);
 
+        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
+        assert(it != _conn_stat_map.end());
+        it->second.read_started(msg->data_size);
+
         send_data(conn, *iov, msg->sn, cb);
 
         // send response as data
@@ -697,16 +739,27 @@ public:
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
         w->init(this, conn, msg->sn, iov, &_curr_state.write_count);
 
+        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
+        assert(it != _conn_stat_map.end());
+        it->second.write_started(msg->data_size);
         recv_data(conn, *iov, msg->sn, w);
     }
 
     virtual void dispatch_connection_accepted(UcxConnection* conn) {
+        bool res = _conn_stat_map.insert(
+                std::make_pair(conn->id(), ConnectionState())).second;
+        assert(res);
         ++_curr_state.active_conns;
     }
 
     virtual void dispatch_connection_error(UcxConnection *conn) {
         LOG << "disconnecting connection with status "
             << ucs_status_string(conn->ucx_status());
+
+        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
+        assert(it != _conn_stat_map.end());
+        _conn_stat_map.erase(it);
+
         --_curr_state.active_conns;
         conn->disconnect(new UcxDisconnectCallback(*conn));
     }
@@ -742,12 +795,41 @@ private:
         memory_pin_stats_t pin_stats;
         memory_pin_stats(&pin_stats);
 
-        LOG << "read:" << _curr_state.read_count - _prev_state.read_count
+        conn_stat_map_t::iterator it_min = _conn_stat_map.begin(),
+                                  it_max = _conn_stat_map.begin();
+        for (conn_stat_map_t::iterator it = _conn_stat_map.begin();
+             it != _conn_stat_map.end(); ++it) {
+            long i_val = it->second.get_total_count();
+            if (i_val <= it_min->second.get_total_count()) {
+                it_min = it;
+            } else if (i_val >= it_max->second.get_total_count()) {
+                it_max = it;
+            } else {
+                it->second.reset();
+            }
+        }
+
+        UcxLog log(LOG_PREFIX);
+        log << "read:" << _curr_state.read_count - _prev_state.read_count
             << " ops, "
             << "write:" << _curr_state.write_count - _prev_state.write_count
             << " ops, "
-            << "active connections:" << _curr_state.active_conns
-            << ", buffers:" << _data_buffers_pool.allocated()
+            << "active connections:" << _curr_state.active_conns;
+
+        if (_curr_state.active_conns > 0) {
+            log << ", min:" << it_min->second.get_total_count() << "/"
+                << it_min->second.get_total_bytes() / double(UCS_MBYTE)
+                << "MB, (" << get_connection(it_min->first).get_peer_name()
+                << ")"
+                << ", max:" << it_max->second.get_total_count() << "/"
+                << it_max->second.get_total_bytes() / double(UCS_MBYTE)
+                << "MB, (" << get_connection(it_max->first).get_peer_name()
+                << ")";
+            it_min->second.reset();
+            it_max->second.reset();
+        }
+
+        log << ", buffers:" << _data_buffers_pool.allocated()
             << ", pin bytes:" << pin_stats.bytes
             << " regions:" << pin_stats.regions
             << " evict:" << pin_stats.evictions;
@@ -755,7 +837,10 @@ private:
     }
 
 private:
+    typedef std::map<uint32_t, ConnectionState> conn_stat_map_t;
+
     MemoryPool<IoWriteResponseCallback> _callback_pool;
+    conn_stat_map_t                     _conn_stat_map;
     state_t                             _prev_state;
     state_t                             _curr_state;
 };

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -10,6 +10,7 @@
 #include <ucp/api/ucp.h>
 #include <ucs/algorithm/crc.h>
 #include <ucs/datastruct/list.h>
+#include <ucs/sys/math.h>
 #include <ucs/sys/sock.h>
 #include <deque>
 #include <exception>
@@ -124,6 +125,8 @@ public:
     void destroy_connections();
 
     static double get_time();
+
+    UcxConnection &get_connection(uint64_t id) const;
 
 protected:
 
@@ -256,6 +259,10 @@ public:
         return _establish_cb == NULL;
     }
 
+    const std::string& get_peer_name() const {
+        return _remote_address;
+    }
+
     bool is_disconnecting() const {
         return _disconnect_cb != NULL;
     }
@@ -310,6 +317,7 @@ private:
     uint64_t        _remote_conn_id;
     char            _log_prefix[MAX_LOG_PREFIX_SIZE];
     ucp_ep_h        _ep;
+    std::string     _remote_address;
     void            *_close_request;
     ucs_list_link_t _all_requests;
     ucs_status_t    _ucx_status;


### PR DESCRIPTION
```
[1619535443.311214] [DEMO] read:90184 ops, write:90162 ops, active connections:3, min:57176/223.344MB, (2.1.3.9:58507), max:61829/241.52MB, (2.1.3.9:55453), buffers:3, pin bytes:13594624 regions:10 evict:0
[1619535444.312027] [DEMO] read:92721 ops, write:92726 ops, active connections:3, min:59457/232.254MB, (2.1.3.9:58507), max:123881/483.91MB, (2.1.3.9:51737), buffers:3, pin bytes:13594624 regions:10 evict:0
[1619535445.312142] [DEMO] read:93596 ops, write:93577 ops, active connections:3, min:60224/235.25MB, (2.1.3.9:58507), max:64174/250.68MB, (2.1.3.9:55453), buffers:3, pin bytes:13594624 regions:10 evict:0
```
@yosefe @alinask pls review