### PR TITLE
UCP/WORKER: err handler fix

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -414,8 +414,6 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
         }
     }
 
-    ucp_stream_ep_cleanup(ucp_ep);
-
     /* Move failed lane to index 0 */
     if ((failed_lane != 0) && (failed_lane != UCP_NULL_LANE)) {
         ucp_ep->uct_eps[0] = ucp_ep->uct_eps[failed_lane];
@@ -454,13 +452,6 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
 
     ucp_ep->am_lane = 0;
 
-    if (!(ucp_ep->flags & UCP_EP_FLAG_USED)) {
-        ucs_debug("ep %p: destroy internal endpoint due to peer failure", ucp_ep);
-        ucp_ep_disconnected(ucp_ep, 1);
-    } else {
-        ucp_ep_invoke_err_cb(ucp_ep, key.status);
-    }
-
     if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
         /* Promote close operation to CANCEL in case of transport error, since
          * the disconnect event may never arrive.
@@ -468,6 +459,11 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
         close_req = ucp_ep_ext_gen(ucp_ep)->close_req.req;
         close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
         ucp_ep_local_disconnect_progress(close_req);
+    } else if (ucp_ep->flags & UCP_EP_FLAG_USED) {
+        ucp_ep_invoke_err_cb(ucp_ep, key.status);
+    } else {
+        ucs_debug("ep %p: destroy internal endpoint due to peer failure", ucp_ep);
+        ucp_ep_disconnected(ucp_ep, 1);
     }
 
     ucs_free(err_handle_arg);


### PR DESCRIPTION
do not access ucp_ep after either:
 - it's destroyed
 - its error callback has beed invoked sinse the app can destroy
   the endpoint as well