### PR TITLE
UCP/PROTO: cancel RNDV recv on failed EP

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -1113,7 +1113,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr, rts_seq),
     rreq->flags                   |= UCP_REQUEST_FLAG_RNDV_MATCHED;
 
     ep = ucp_worker_get_ep_by_ptr(worker, rndv_rts_hdr->sreq.ep_ptr);
-    if (ep == NULL) {
+    if ((ep == NULL) || (ep->flags & UCP_EP_FLAG_FAILED)) {
         ucp_request_complete_tag_recv(worker, rreq, UCS_ERR_CANCELED, "rndv_no_ep");
         goto out;
     }


### PR DESCRIPTION
Fixes iodemo hang on _iomsg_recv_request with rndv thresh = 0 if RTS handler is invoked on failed EP

@yosefe @dmitrygx pls take a look