### PR TITLE
TEST/IODEMO: Fix corruption in random_shuffle

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -178,7 +178,7 @@ public:
         assert(max < std::numeric_limits<unsigned_type>::max());
         assert(unsigned_type(0) == std::numeric_limits<unsigned_type>::min());
 
-        return rand(_seed, unsigned_type(0), max);
+        return rand(_seed, unsigned_type(0), max - 1);
     }
 
     static inline void fill(unsigned &seed, void *buffer, size_t size) {


### PR DESCRIPTION
## Why
Backport #6496 