### PR TITLE
TEST/IODEMO: Fix corruption in random_shuffle

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -178,7 +178,7 @@ public:
         assert(max < std::numeric_limits<unsigned_type>::max());
         assert(unsigned_type(0) == std::numeric_limits<unsigned_type>::min());
 
-        return rand(_seed, unsigned_type(0), max);
+        return rand(_seed, unsigned_type(0), max - 1);
     }
 
     static inline void fill(unsigned &seed, void *buffer, size_t size) {


### PR DESCRIPTION
The randomizer passed random_shuffle should return values within
0..max-1 and not 0..max. Without this fix, the resulting server list
could be corrupted, leading to segfault when trying to connect to last
server in the list.

cherry-picked from https://github.com/openucx/ucx/pull/6496