### PR TITLE
UCS/TEST/STRING: Fix string buffer grow

### DIFF
--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -41,6 +41,24 @@ UCS_TEST_F(test_string_buffer, appendf) {
     ucs_string_buffer_cleanup(&strb);
 }
 
+UCS_TEST_F(test_string_buffer, append_long) {
+    ucs_string_buffer_t strb;
+    std::string str;
+
+    str.resize(100);
+    std::fill(str.begin(), str.end(), 'e');
+
+    ucs_string_buffer_init(&strb);
+
+    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
+    EXPECT_EQ(str.c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+
+    ucs_string_buffer_appendf(&strb, "%s", str.c_str());
+    EXPECT_EQ((str + str).c_str(), std::string(ucs_string_buffer_cstr(&strb)));
+
+    ucs_string_buffer_cleanup(&strb);
+}
+
 UCS_TEST_F(test_string_buffer, rtrim) {
     static const char *test_string = "wabbalubbadabdab";
     ucs_string_buffer_t strb;


### PR DESCRIPTION
Porting https://github.com/openucx/ucx/pull/5286, no merge conflicts
Fixing `string_buffer.c:103 Assertion `ret < max_print' failed`