### PR TITLE
IO-DEMO: fixed memory leak - int3

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -739,6 +739,7 @@ bool UcxConnection::recv_data(void *buffer, size_t length, uint32_t sn,
                               UcxCallback* callback)
 {
     if (_ep == NULL) {
+        (*callback)(UCS_ERR_CANCELED);
         return false;
     }
 
@@ -940,6 +941,7 @@ bool UcxConnection::send_common(const void *buffer, size_t length, ucp_tag_t tag
                                 UcxCallback* callback)
 {
     if (_ep == NULL) {
+        (*callback)(UCS_ERR_CANCELED);
         return false;
     }
 


### PR DESCRIPTION
- there was memory leak in send_io_message routine
  when connection is in "disconnecting" state
- added callback notification to allow release object

backport from https://github.com/openucx/ucx/pull/7125