### PR TITLE
IB/IFACE: deny iface create if DEVX rcqp requested

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1022,6 +1022,12 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_ib_iface_ops_t *ops, uct_md_h md,
         goto err; 
     }
 
+    if (ib_md->devx_objs & UCS_BIT(UCT_IB_DEVX_OBJ_RCQP)) {
+        ucs_error("DEVX object 'rcqp' is not supported");
+        status = UCS_ERR_UNSUPPORTED;
+        goto err;
+    }
+
     if (!(params->open_mode & UCT_IFACE_OPEN_MODE_DEVICE)) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1493,6 +1493,7 @@ ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
         goto out_free_dev_list;
     }
 
+    md->devx_objs = md_config->devx_objs;
     /* cppcheck-suppress autoVariables */
     *md_p = &md->super;
     status = UCS_OK;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -115,6 +115,7 @@ typedef struct uct_ib_md {
     int                      check_subnet_filter;
     uint64_t                 subnet_filter;
     double                   pci_bw;
+    unsigned                 devx_objs; /**< Objects to be created by DevX */
 } uct_ib_md_t;
 
 


### PR DESCRIPTION
- deny IB iface creation if DEVX rcqp object was enabled on MD