### PR TITLE
IODEMO/LOG: added logging of handles signals

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -480,6 +480,8 @@ protected:
 
     static void signal_terminate_handler(int signo)
     {
+        LOG << "Run-time signal handling: " << signo;
+
         _status = TERMINATE_SIGNALED;
     }
 
@@ -494,7 +496,7 @@ protected:
         _data_chunks_pool(test_opts.chunk_size, "data chunks",
                           test_opts.num_offcache_buffers)
     {
-        _status                 = OK;
+        _status                  = OK;
 
         struct sigaction new_sigaction;
         new_sigaction.sa_handler = signal_terminate_handler;


### PR DESCRIPTION
- added logging of handled signals to simplify logs parsing

(cherry picked from commit 851dbd5e436f6dbae2dbbedea18bb23dcdf77957)

backport from https://github.com/openucx/ucx/pull/7287