### PR TITLE
UCP/TAG: support pre-registered buffers

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -536,6 +536,7 @@ typedef enum {
     UCP_OP_ATTR_FIELD_USER_DATA     = UCS_BIT(2),  /**< user_data field */
     UCP_OP_ATTR_FIELD_DATATYPE      = UCS_BIT(3),  /**< datatype field */
     UCP_OP_ATTR_FIELD_FLAGS         = UCS_BIT(4),  /**< operation-specific flags */
+    UCP_OP_ATTR_FIELD_MEMH          = UCS_BIT(5),  /**< memh field */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
@@ -1287,6 +1288,12 @@ typedef struct {
      * default datatype ucp_dt_make_contig(1)
      */
     ucp_datatype_t datatype;
+
+    /**
+     * Memory handler for pre-registered buffer.
+     * Only consider contiguous buffer.
+     */
+    ucp_mem_h memh;
 
     /**
      * Pointer to user data passed to callback function.
@@ -3041,6 +3048,41 @@ ucs_status_ptr_t ucp_tag_recv_nbx(ucp_worker_h worker, void *buffer, size_t coun
 ucp_tag_message_h ucp_tag_probe_nb(ucp_worker_h worker, ucp_tag_t tag,
                                    ucp_tag_t tag_mask, int remove,
                                    ucp_tag_recv_info_t *info);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking receive operation for a probed message.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a message handle on the @a worker.
+ * The @a message handle can be obtained by calling the @ref
+ * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nbx
+ * "ucp_tag_msg_recv_nbx()" routine is non-blocking and therefore returns
+ * immediately. The receive operation is considered completed when the message
+ * is delivered to the @a buffer. In order to notify the application about
+ * completion of the receive operation the UCP library will invoke the
+ * call-back @a cb when the received message is in the receive buffer and ready
+ * for application access. If the receive operation cannot be started the
+ * routine returns an error.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer that will receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  message     Message handle.
+ * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise            - Operation was scheduled for receive. The request
+ *                                handle is returned to the application in order
+ *                                to track progress of the operation. The
+ *                                application is responsible for releasing the
+ *                                handle using @ref ucp_request_free
+ *                                "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
+                                      size_t count, ucp_tag_message_h message,
+                                      const ucp_request_param_t *param);
 
 
 /**

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -69,8 +69,12 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             /* memh not needed and registered, deregister it */
             ucs_trace("de-registering memh[%d]=%p from md[%d]", memh_index,
                       uct_memh[memh_index], md_index);
-            status = uct_md_mem_dereg(context->tl_mds[md_index].md,
-                                      uct_memh[memh_index]);
+            if (uct_flags & UCT_MD_MEM_FLAG_MEMH) {
+                status = UCS_OK;
+            } else {
+                status = uct_md_mem_dereg(context->tl_mds[md_index].md,
+                                          uct_memh[memh_index]);
+            }
             if (status != UCS_OK) {
                 ucs_warn("failed to dereg from md[%d]=%s: %s", md_index,
                          context->tl_mds[md_index].rsc.md_name,
@@ -112,8 +116,13 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
                 ucs_assert(address && length);
 
                 /* MD supports registration, register new memh on it */
-                status = uct_md_mem_reg(context->tl_mds[md_index].md, address,
-                        length, uct_flags, &uct_memh[memh_index]);
+                if (uct_flags & UCT_MD_MEM_FLAG_MEMH) {
+                    uct_memh[memh_index] = ucp_memh2uct(address, md_index);
+                    status = UCS_OK;
+                } else {
+                    status = uct_md_mem_reg(context->tl_mds[md_index].md, address,
+                            length, uct_flags, &uct_memh[memh_index]);
+                }
             }
 
             if (status == UCS_OK) {

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -210,7 +210,7 @@ static void ucp_request_dt_dereg(ucp_context_t *context, ucp_dt_reg_t *dt_reg,
     for (i = 0; i < count; ++i) {
         ucp_trace_req(req_dbg, "mem dereg buffer %ld/%ld md_map 0x%"PRIx64,
                       i, count, dt_reg[i].md_map);
-        ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, UCS_MEMORY_TYPE_HOST, NULL,
+        ucp_mem_rereg_mds(context, 0, NULL, 0, req_dbg->memh ? UCT_MD_MEM_FLAG_MEMH : 0, NULL, UCS_MEMORY_TYPE_HOST, NULL,
                           dt_reg[i].memh, &dt_reg[i].md_map);
         ucs_assert(dt_reg[i].md_map == 0);
     }
@@ -237,6 +237,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {
     case UCP_DATATYPE_CONTIG:
         ucs_assert(ucs_popcount(md_map) <= UCP_MAX_OP_MDS);
+        if (req_dbg->memh) {
+            buffer = req_dbg->memh;
+            flags |= UCT_MD_MEM_FLAG_MEMH;
+        }
         status = ucp_mem_rereg_mds(context, md_map, buffer, length, flags,
                                    NULL, mem_type, NULL, state->dt.contig.memh,
                                    &state->dt.contig.md_map);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -111,6 +111,7 @@ struct ucp_request {
     ucs_status_t                  status;  /* Operation status */
     uint32_t                      flags;   /* Request flags */
     void                          *user_data;
+    ucp_mem_h                     memh;    /* Memory handler for pre-registered buffer */
 
     union {
 
@@ -279,7 +280,7 @@ struct ucp_request {
                     ucp_tag_t               tag;      /* Expected tag */
                     ucp_tag_t               tag_mask; /* Expected tag mask */
                     uint64_t                sn;       /* Tag match sequence */
-                    ucp_tag_recv_callback_t cb;       /* Completion callback */
+                    ucp_tag_recv_nbx_callback_t cb;       /* Completion callback */
                     ucp_tag_recv_info_t     info;     /* Completion info to fill */
                     ssize_t                 remaining; /* How much more data to be received */
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -100,6 +100,38 @@
         __req; \
     })
 
+#define ucp_request_id_check(_req, _cmp, _id) \
+    ucs_assertv((_req)->id _cmp (_id), "req=%p req->id=0x%" PRIx64 " id=0x%" \
+                PRIx64, \
+                (_req), (_req)->id, (_id))
+
+#define ucp_request_put_param(_param, _req) \
+    if (!((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) { \
+        ucp_request_put(_req); \
+    } else { \
+        ucp_request_id_check(_req, ==, UCS_PTR_MAP_KEY_INVALID); \
+    }
+
+
+#define ucp_request_cb_param(_param, _req, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
+        param->cb._cb(req + 1, (_req)->status, ##__VA_ARGS__, param->user_data); \
+    }
+
+
+#define ucp_request_imm_cmpl_param(_param, _req, _cb, ...) \
+    if ((_param)->op_attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) { \
+        ucp_request_cb_param(_param, _req, _cb, ##__VA_ARGS__); \
+        ucs_trace_req("request %p completed, but immediate completion is " \
+                      "prohibited, status %s", _req, \
+                      ucs_status_string((_req)->status)); \
+        return (_req) + 1; \
+    } \
+    { \
+        ucs_status_t _status = (_req)->status; \
+        ucp_request_put_param(_param, _req); \
+        return UCS_STATUS_PTR(_status); \
+    }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_request_put(ucp_request_t *req)
@@ -109,6 +141,7 @@ ucp_request_put(ucp_request_t *req)
     req->send.cb        = NULL;
     req->recv.tag.cb    = NULL;
     req->recv.stream.cb = NULL;
+    req->memh           = NULL;
     ucs_mpool_put_inline(req);
 }
 
@@ -143,7 +176,7 @@ ucp_request_complete_tag_recv(ucp_worker_h worker, ucp_request_t *req,
      }
 
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", status);
-    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info);
+    ucp_request_complete(req, recv.tag.cb, status, &req->recv.tag.info, req->user_data);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -642,6 +675,20 @@ ucp_request_param_flags(const ucp_request_param_t *param)
 {
     return (param->op_attr_mask & UCP_OP_ATTR_FIELD_FLAGS) ?
            param->flags : 0;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_datatype_t
+ucp_request_param_datatype(const ucp_request_param_t *param)
+{
+    return (param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE) ?
+           param->datatype : ucp_dt_make_contig(1);
+}
+
+static UCS_F_ALWAYS_INLINE ucp_mem_h
+ucp_request_param_memh(const ucp_request_param_t *param)
+{
+    return (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMH) ?
+           param->memh : NULL;
 }
 
 #endif

--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -855,6 +855,7 @@ static void ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req, ucp_request_t *rr
     rndv_req->send.rndv_get.remote_address = rndv_rts_hdr->address;
     rndv_req->send.rndv_get.rreq           = rreq;
     rndv_req->send.datatype                = rreq->recv.datatype;
+    rndv_req->memh                         = rreq->memh;
 
     status = ucp_ep_rkey_unpack(rndv_req->send.ep, rndv_rts_hdr + 1,
                                 &rndv_req->send.rndv_get.rkey);
@@ -1126,6 +1127,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_matched, (worker, rreq, rndv_rts_hdr, rts_seq),
         goto out;
     }
 
+    rndv_req->memh              = NULL;
     rndv_req->send.ep           = ep;
     rndv_req->flags             = 0;
     rndv_req->send.mdesc        = NULL;

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -38,9 +38,7 @@ ucp_tag_recv_request_completed(ucp_worker_h worker, ucp_request_t *req,
     }
 
     req->status = status;
-    if ((req->flags |= UCP_REQUEST_FLAG_COMPLETED) & UCP_REQUEST_FLAG_RELEASED) {
-        ucp_request_put(req);
-    }
+    req->flags |= UCP_REQUEST_FLAG_COMPLETED;
     UCS_PROFILE_REQUEST_EVENT(req, "complete_recv", 0);
 }
 
@@ -65,13 +63,15 @@ ucp_tag_recv_add_debug_entry(ucp_worker_h worker, void *buffer, size_t length,
     entry->send_req       = NULL;
 }
 
-static UCS_F_ALWAYS_INLINE void
+static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                     uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
-                    ucp_request_t *req, uint32_t req_flags, ucp_tag_recv_callback_t cb,
-                    ucp_recv_desc_t *rdesc, const char *debug_name)
+                    ucp_request_t *req, ucp_recv_desc_t *rdesc,
+                    const ucp_request_param_t *param, const char *debug_name)
 {
     unsigned common_flags = UCP_REQUEST_FLAG_RECV | UCP_REQUEST_FLAG_EXPECTED;
+    uint32_t req_flags = (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) ?
+                         UCP_REQUEST_FLAG_CALLBACK : 0;
     ucp_eager_first_hdr_t *eagerf_hdr;
     ucp_request_queue_t *req_queue;
     ucs_memory_type_t mem_type;
@@ -118,12 +118,17 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                                     recv_len, 1);
         ucp_recv_desc_release(rdesc);
 
-        if (req_flags & UCP_REQUEST_FLAG_CALLBACK) {
-            cb(req + 1, status, &req->recv.tag.info);
-        }
         ucp_tag_recv_request_completed(worker, req, buffer, status,
                                        &req->recv.tag.info, debug_name);
-        return;
+
+        ucp_request_imm_cmpl_param(param, req, recv, &req->recv.tag.info);
+    }
+
+    /* TODO: allocate request only in case if flag
+     * UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL is not set */
+    if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
+        ucp_request_put_param(param, req);
+        return UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
     }
 
     /* Initialize receive request */
@@ -145,8 +150,17 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                                                      req->recv.length);
     req->recv.tag.tag       = tag;
     req->recv.tag.tag_mask  = tag_mask;
-    req->recv.tag.cb        = cb;
+    if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
+        req->recv.tag.cb    = param->cb.recv;
+
+        if (param->op_attr_mask & UCP_OP_ATTR_FIELD_USER_DATA) {
+            req->user_data = param->user_data;
+        } else {
+            req->user_data = NULL;
+        }
+    }
     req->recv.tag.rndv_req  = NULL;
+    req->memh = ucp_request_param_memh(param);
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
         req->recv.tag.info.sender_tag = 0;
     }
@@ -164,7 +178,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
         ucs_trace_req("%s returning expected request %p (%p)", debug_name, req,
                       req + 1);
-        return;
+        return req + 1;
     }
 
     /* Check rendezvous case */
@@ -172,7 +186,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
         ucp_rndv_matched(worker, req, (void*)(rdesc + 1), rdesc->rndv_rts_seq);
         UCP_WORKER_STAT_RNDV(worker, UNEXP);
         ucp_recv_desc_release(rdesc);
-        return;
+        return req + 1;
     }
 
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_EAGER_SYNC)) {
@@ -190,89 +204,49 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
     msg_id = eagerf_hdr->msg_id;
     status = ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
-    ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS));
+    ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS) ||
+               (status == UCS_ERR_MESSAGE_TRUNCATED));
 
     /* process additional fragments */
     ucp_tag_frag_list_process_queue(&worker->tm, req, msg_id, eagerf_hdr->super.ep_ptr
                                     UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP));
+    return req + 1;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_recv_nbr,
                  (worker, buffer, count, datatype, tag, tag_mask, request),
                  ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
                  void *request)
 {
-    ucp_request_t *req = (ucp_request_t *)request - 1;
-    ucp_recv_desc_t *rdesc;
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FIELD_REQUEST  |
+                        UCP_OP_ATTR_FLAG_NO_IMM_CMPL,
+        .request      = request,
+        .datatype     = datatype
+    };
+    ucs_status_ptr_t status;
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
-                                    return UCS_ERR_INVALID_PARAM);
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
-
-    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbr");
-    ucp_tag_recv_common(worker, buffer, count, datatype, tag, tag_mask,
-                        req, UCP_REQUEST_DEBUG_FLAG_EXTERNAL, NULL, rdesc,
-                        "recv_nbr");
-
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
-    return UCS_OK;
+    status = ucp_tag_recv_nbx(worker, buffer, count, tag, tag_mask, &param);
+    return UCS_PTR_IS_ERR(status) ? UCS_PTR_STATUS(status) : UCS_OK;
 }
 
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nb,
                  (worker, buffer, count, datatype, tag, tag_mask, cb),
                  ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
+                 ucp_datatype_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
                  ucp_tag_recv_callback_t cb)
 {
-    ucp_recv_desc_t *rdesc;
-    ucs_status_ptr_t ret;
-    ucp_request_t *req;
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FLAG_NO_IMM_CMPL,
+        .cb.recv      = (ucp_tag_recv_nbx_callback_t)cb,
+        .datatype     = datatype
+    };
 
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
-                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
-
-    req = ucp_request_get(worker);
-    if (ucs_likely(req != NULL)) {
-        rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nb");
-        ucp_tag_recv_common(worker, buffer, count, datatype, tag, tag_mask, req,
-                            UCP_REQUEST_FLAG_CALLBACK, cb, rdesc,"recv_nb");
-        ret = req + 1;
-    } else {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-    }
-
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
-    return ret;
-}
-
-UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nb,
-                 (worker, buffer, count, datatype, message, cb),
-                 ucp_worker_h worker, void *buffer, size_t count,
-                 uintptr_t datatype, ucp_tag_message_h message,
-                 ucp_tag_recv_callback_t cb)
-{
-    ucp_recv_desc_t *rdesc = message;
-    ucs_status_ptr_t ret;
-    ucp_request_t *req;
-
-    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
-                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
-    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
-
-    req = ucp_request_get(worker);
-    if (ucs_likely(req != NULL)) {
-        ucp_tag_recv_common(worker, buffer, count, datatype,
-                            ucp_rdesc_get_tag(rdesc), UCP_TAG_MASK_FULL, req,
-                            UCP_REQUEST_FLAG_CALLBACK, cb, rdesc, "msg_recv_nb");
-        ret = req + 1;
-    } else {
-        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-    }
-
-    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
-    return ret;
+    return ucp_tag_recv_nbx(worker, buffer, count, tag, tag_mask, &param);
 }
 
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
@@ -281,5 +255,69 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
                  ucp_tag_t tag, ucp_tag_t tag_mask,
                  const ucp_request_param_t *param)
 {
-    return UCS_STATUS_PTR(UCS_ERR_NOT_IMPLEMENTED);
+    ucp_recv_desc_t *rdesc;
+    ucs_status_ptr_t ret;
+    ucp_request_t *req;
+    ucp_datatype_t datatype;
+
+    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
+                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
+
+    datatype = ucp_request_param_datatype(param);
+    req      = ucp_request_get_param(worker, param,
+                                     {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                      goto out;});
+
+    rdesc    = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbx");
+    ret      = ucp_tag_recv_common(worker, buffer, count, datatype, tag,
+                                   tag_mask, req, rdesc, param, "recv_nbx");
+
+out:
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
+    return ret;
+}
+
+ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer, size_t count,
+                                     ucp_datatype_t datatype, ucp_tag_message_h message,
+                                     ucp_tag_recv_callback_t cb)
+{
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FLAG_NO_IMM_CMPL,
+        .datatype     = datatype,
+        .cb.recv      = (ucp_tag_recv_nbx_callback_t)cb
+    };
+
+    return ucp_tag_msg_recv_nbx(worker, buffer, count, message, &param);
+}
+
+UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nbx,
+                 (worker, buffer, count, message, param),
+                 ucp_worker_h worker, void *buffer, size_t count,
+                 ucp_tag_message_h message, const ucp_request_param_t *param)
+{
+    ucp_recv_desc_t *rdesc = message;
+    ucs_status_ptr_t ret;
+    ucp_request_t *req;
+    ucp_datatype_t datatype;
+
+    UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
+                                    return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
+
+    req      = ucp_request_get_param(worker, param,
+                                     {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                     goto out;});
+    datatype = ucp_request_param_datatype(param);
+    ret      =  ucp_tag_recv_common(worker, buffer, count, datatype,
+                                    ucp_rdesc_get_tag(rdesc), UCP_TAG_MASK_FULL,
+                                    req, rdesc, param, "msg_recv_nbx");
+
+out:
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
+    return ret;
 }

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -382,6 +382,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
     }
 
     ucp_tag_send_req_init(req, ep, buffer, datatype, count, tag, 0);
+    req->memh = ucp_request_param_memh(param);
     ret = ucp_tag_send_req(req, count, &ucp_ep_config(ep)->tag.eager,
                            rndv_rma_thresh, rndv_am_thresh,
                            cb, ucp_ep_config(ep)->tag.proto,

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -666,6 +666,9 @@ enum uct_md_mem_flags {
                                                    In some cases registration failure
                                                    is not an error (e. g. for merged
                                                    memory regions). */
+    UCT_MD_MEM_FLAG_MEMH        = UCS_BIT(4), /**< Indicates pre-registered buffer
+                                                   instead of buffer to be registered
+                                                   */
 
     /* memory access flags */
     UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), /**< enable remote put access */

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -129,12 +129,16 @@ public:
         return _name;
     }
 
+    virtual T* construct() {
+        return new T(_buffer_size, *this);
+    }
+
 private:
     inline T* get_free() {
         T* item;
 
         if (_free_stack.empty()) {
-            item = new T(_buffer_size, *this);
+            item = construct();
             _num_allocated++;
         } else {
             item = _free_stack.back();
@@ -147,8 +151,28 @@ private:
     std::vector<T*> _free_stack;
     std::queue<T*>  _offcache_queue;
     uint32_t        _num_allocated;
+protected:
     size_t          _buffer_size;
+private:
     std::string     _name;
+};
+
+template<typename BufferType>
+class ContextMemoryPool : public MemoryPool<BufferType, true> {
+public:
+    ContextMemoryPool(size_t buffer_size, const std::string& name, UcxContext* context) :
+            MemoryPool<BufferType, true>(buffer_size, name),
+            _context(context)
+    {
+    }
+
+    virtual BufferType* construct()
+    {
+        return new BufferType(this->_buffer_size, *this, _context);
+    }
+
+private:
+    UcxContext* _context;
 };
 
 /**
@@ -272,17 +296,26 @@ protected:
 
     class Buffer {
     public:
-        Buffer(size_t size, MemoryPool<Buffer, true>& pool) :
+        Buffer(size_t size, MemoryPool<Buffer, true>& pool, UcxContext* context=NULL) :
             _capacity(size),
-            _buffer(UcxContext::memalign(ALIGNMENT, size, pool.name().c_str())),
-            _size(0), _pool(pool) {
+            _buffer(NULL), _memh(NULL),
+            _size(0), _pool(pool), _context(context) {
+            if (_context == NULL) {
+                _buffer = UcxContext::memalign(ALIGNMENT, size, pool.name().c_str());
+            } else {
+                _context->alloc_mapped_buffer(size, &_buffer, &_memh, 0);
+            }
             if (_buffer == NULL) {
                 throw std::bad_alloc();
             }
         }
 
         ~Buffer() {
-            UcxContext::free(_buffer);
+            if (_context == NULL) {
+                UcxContext::free(_buffer);
+            } else {
+                assert(_context->free_mapped_buffer(_memh) == UCS_OK);
+            }
         }
 
         void release() {
@@ -291,6 +324,10 @@ protected:
 
         inline void *buffer(size_t offset = 0) const {
             return (uint8_t*)_buffer + offset;
+        }
+
+        inline ucp_mem_h memh() {
+            return _memh;
         }
 
         inline void resize(size_t size) {
@@ -307,8 +344,10 @@ protected:
 
     private:
         void*                     _buffer;
+        ucp_mem_h                 _memh;
         size_t                    _size;
         MemoryPool<Buffer, true>& _pool;
+        UcxContext*               _context;
     };
 
     class BufferIov {
@@ -494,7 +533,8 @@ protected:
         _data_buffers_pool(get_chunk_cnt(test_opts.max_data_size,
                                          test_opts.chunk_size), "data iovs"),
         _data_chunks_pool(test_opts.chunk_size, "data chunks",
-                          test_opts.num_offcache_buffers)
+                          test_opts.num_offcache_buffers),
+        _mapped_chunks_pool(test_opts.chunk_size, "mapped chunks", this)
     {
         _status                  = OK;
 
@@ -531,9 +571,9 @@ protected:
                         UcxCallback* callback = EmptyCallback::get()) {
         for (size_t i = 0; i < iov.size(); ++i) {
             if (send_recv_data == XFER_TYPE_SEND) {
-                conn->send_data(iov[i].buffer(), iov[i].size(), sn, callback);
+                conn->send_data(iov[i].buffer(), iov[i].memh(), iov[i].size(), sn, callback);
             } else {
-                conn->recv_data(iov[i].buffer(), iov[i].size(), sn, callback);
+                conn->recv_data(iov[i].buffer(), iov[i].memh(), iov[i].size(), sn, callback);
             }
         }
     }
@@ -599,7 +639,7 @@ private:
         /* send IO_READ_COMP as a data since the transaction must be matched
          * by sn on receiver side */
         if (msg->msg()->op == IO_READ_COMP) {
-            return conn->send_data(msg->buffer(), opts().iomsg_size,
+            return conn->send_data(msg->buffer(), NULL, opts().iomsg_size,
                                    msg->msg()->sn, msg);
         } else {
             return conn->send_io_message(msg->buffer(), opts().iomsg_size, msg);
@@ -612,6 +652,7 @@ protected:
     MemoryPool<SendCompleteCallback> _send_callback_pool;
     MemoryPool<BufferIov>            _data_buffers_pool;
     MemoryPool<Buffer, true>         _data_chunks_pool;
+    ContextMemoryPool<Buffer>        _mapped_chunks_pool;
     static status_t                  _status;
 };
 
@@ -802,7 +843,7 @@ public:
         SendCompleteCallback *cb  = _send_callback_pool.get();
         ConnectionStat &conn_stat = _conn_stat_map.find(conn)->second;
 
-        iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
+        iov->init(msg->data_size, _mapped_chunks_pool, msg->sn, opts().validate);
         cb->init(iov, &conn_stat.completions<IO_READ>());
 
         conn_stat.bytes<IO_READ>() += msg->data_size;
@@ -821,7 +862,7 @@ public:
         IoWriteResponseCallback *w = _callback_pool.get();
         ConnectionStat &conn_stat  = _conn_stat_map.find(conn)->second;
 
-        iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
+        iov->init(msg->data_size, _mapped_chunks_pool, msg->sn, opts().validate);
         w->init(this, conn, msg->sn, iov, &conn_stat.completions<IO_WRITE>());
 
         conn_stat.bytes<IO_WRITE>() += msg->data_size;
@@ -1133,11 +1174,11 @@ public:
 
         commit_operation(server_index, IO_READ, data_size);
 
-        iov->init(data_size, _data_chunks_pool, sn, validate);
+        iov->init(data_size, _mapped_chunks_pool, sn, validate);
         r->init(this, server_index, sn, validate, iov);
 
         recv_data(server_info.conn, *iov, sn, r);
-        server_info.conn->recv_data(r->buffer(), opts().iomsg_size, sn, r);
+        server_info.conn->recv_data(r->buffer(), NULL, opts().iomsg_size, sn, r);
 
         return data_size;
     }
@@ -1157,7 +1198,7 @@ public:
 
         commit_operation(server_index, IO_WRITE, data_size);
 
-        iov->init(data_size, _data_chunks_pool, sn, validate);
+        iov->init(data_size, _mapped_chunks_pool, sn, validate);
         cb->init(iov, NULL);
 
         VERBOSE_LOG << "sending data " << iov << " size "

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -645,6 +645,43 @@ void UcxContext::free(void *ptr)
     ::free(ptr);
 }
 
+ucs_status_t UcxContext::alloc_mapped_buffer(size_t length,
+                         void **address_p, ucp_mem_h *memh, int non_blk_flag)
+{
+    ucp_mem_map_params_t mem_map_params;
+    ucp_mem_attr_t mem_attr;
+    ucs_status_t status;
+
+    mem_map_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                UCP_MEM_MAP_PARAM_FIELD_LENGTH |
+                                UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+    mem_map_params.address    = *address_p;
+    mem_map_params.length     = length;
+    mem_map_params.flags      = UCP_MEM_MAP_ALLOCATE;
+    mem_map_params.flags |= non_blk_flag;
+
+    status = ucp_mem_map(_context, &mem_map_params, memh);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    mem_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS;
+    status = ucp_mem_query(*memh, &mem_attr);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    *address_p = mem_attr.address;
+    return UCS_OK;
+
+err:
+    return status;
+}
+
+ucs_status_t UcxContext::free_mapped_buffer(ucp_mem_h memh)
+{
+    return ucp_mem_unmap(_context, memh);
+}
 
 #define UCX_CONN_LOG UcxLog(_log_prefix, true)
 
@@ -768,17 +805,17 @@ bool UcxConnection::send_io_message(const void *buffer, size_t length,
                                     UcxCallback* callback)
 {
     ucp_tag_t tag = make_iomsg_tag(_remote_conn_id, 0);
-    return send_common(buffer, length, tag, callback);
+    return send_common(buffer, NULL, length, tag, callback);
 }
 
-bool UcxConnection::send_data(const void *buffer, size_t length, uint32_t sn,
+bool UcxConnection::send_data(const void *buffer, ucp_mem_h memh, size_t length, uint32_t sn,
                               UcxCallback* callback)
 {
     ucp_tag_t tag = make_data_tag(_remote_conn_id, sn);
-    return send_common(buffer, length, tag, callback);
+    return send_common(buffer, memh, length, tag, callback);
 }
 
-bool UcxConnection::recv_data(void *buffer, size_t length, uint32_t sn,
+bool UcxConnection::recv_data(void *buffer, ucp_mem_h memh, size_t length, uint32_t sn,
                               UcxCallback* callback)
 {
     if (_ep == NULL) {
@@ -788,11 +825,20 @@ bool UcxConnection::recv_data(void *buffer, size_t length, uint32_t sn,
 
     ucp_tag_t tag      = make_data_tag(_conn_id, sn);
     ucp_tag_t tag_mask = std::numeric_limits<ucp_tag_t>::max();
-    ucs_status_ptr_t ptr_status = ucp_tag_recv_nb(_context.worker(), buffer,
-                                                  length, ucp_dt_make_contig(1),
-                                                  tag, tag_mask,
-                                                  data_recv_callback);
-    return process_request("ucp_tag_recv_nb", ptr_status, callback);
+    ucp_request_param_t param;
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    param.datatype     = ucp_dt_make_contig(1);
+    param.cb.recv      = (ucp_tag_recv_nbx_callback_t)data_recv_callback;
+    if (memh) {
+        param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+        param.memh = memh;
+    }
+
+    ucs_status_ptr_t ptr_status = ucp_tag_recv_nbx(_context.worker(), buffer,
+                                                  length, tag, tag_mask, &param);
+    return process_request("ucp_tag_recv_nbx", ptr_status, callback);
 }
 
 void UcxConnection::cancel_all()
@@ -988,7 +1034,7 @@ void UcxConnection::established(ucs_status_t status)
     invoke_callback(_establish_cb, status);
 }
 
-bool UcxConnection::send_common(const void *buffer, size_t length, ucp_tag_t tag,
+bool UcxConnection::send_common(const void *buffer, ucp_mem_h memh, size_t length, ucp_tag_t tag,
                                 UcxCallback* callback)
 {
     ucp_request_param_t params;
@@ -1005,6 +1051,10 @@ bool UcxConnection::send_common(const void *buffer, size_t length, ucp_tag_t tag
         params.flags         = (length >= _context.rndv_thresh()) ?
                                UCP_EP_TAG_SEND_FLAG_RNDV :
                                UCP_EP_TAG_SEND_FLAG_EAGER;
+    }
+    if (memh) {
+        params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+        params.memh = memh;
     }
 
     assert(_ucx_status == UCS_OK);

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -134,6 +134,10 @@ public:
 
     static void free(void *ptr);
 
+    ucs_status_t alloc_mapped_buffer(size_t length, void **address_p, ucp_mem_h *memh, int non_blk_flag);
+
+    ucs_status_t free_mapped_buffer(ucp_mem_h memh);
+
 protected:
 
     // Called when new IO message is received
@@ -268,10 +272,10 @@ public:
     bool send_io_message(const void *buffer, size_t length,
                          UcxCallback* callback = EmptyCallback::get());
 
-    bool send_data(const void *buffer, size_t length, uint32_t sn,
+    bool send_data(const void *buffer, ucp_mem_h memh, size_t length, uint32_t sn,
                    UcxCallback* callback = EmptyCallback::get());
 
-    bool recv_data(void *buffer, size_t length, uint32_t sn,
+    bool recv_data(void *buffer, ucp_mem_h memh, size_t length, uint32_t sn,
                    UcxCallback* callback = EmptyCallback::get());
 
     void cancel_all();
@@ -333,7 +337,7 @@ private:
 
     void established(ucs_status_t status);
 
-    bool send_common(const void *buffer, size_t length, ucp_tag_t tag,
+    bool send_common(const void *buffer, ucp_mem_h memh, size_t length, ucp_tag_t tag,
                      UcxCallback* callback);
 
     void request_started(ucx_request *r);


### PR DESCRIPTION
Enable users to register buffers before sending/receving them. send_nbx/recv_nbx needs add a param field to accommodate memh. That way, pgtable lookup as well as rcache overhead could be avoided. tests show throughput improvement is obvious with the number of buffers increase.