### PR TITLE
DEBUG/SIGNAL: reset SIGINT signal handler on freeze

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -192,6 +192,8 @@ extern char *cplus_demangle(const char *, int);
 #endif
 
 static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol);
+static int orig_sigaction(int signum, const struct sigaction *act,
+                          struct sigaction *oact);
 
 
 static char *ucs_debug_strdup(const char *str)
@@ -916,9 +918,17 @@ static void ucs_debug_send_mail(const char *message)
 
 static void ucs_error_freeze(const char *message)
 {
+    struct sigaction sigact = {
+        .sa_handler = SIG_DFL,
+        .sa_flags   = 0
+    };
     static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
     char response;
     int ret;
+
+    /* restore original SIGINT handler to allow termitate process via Ctrl+C */
+    sigemptyset(&sigact.sa_mask);
+    orig_sigaction(SIGINT, &sigact, NULL);
 
     ucs_debug_stop_other_threads();
 


### PR DESCRIPTION
- in case if error handles is set to FREEZE and process freezed by UCX
  then reset SIGINT siagnal handler into default to allow process to
  be terminated via Ctrl+C

(cherry picked from commit c27e56a1968bb4f835dbb080e9e2dccc4cc3a8f5)

backport from https://github.com/openucx/ucx/pull/7291