### PR TITLE
APPS/IO-DEMO: Use C-string constant instead of std::string

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1094,7 +1094,7 @@ public:
     }
 
     void check_counters(const server_info_t& server_info, io_op_t op,
-                        const std::string &type_str)
+                        const char *type_str)
     {
         ASSERTV(server_info.num_completed[op] < server_info.num_sent[op])
                 << type_str << ": op=" << io_op_names[op] << " num_completed="


### PR DESCRIPTION
backporting of https://github.com/openucx/ucx/pull/7313