### PR TITLE
LOGGING: fixed potential build issue - int3

### DIFF
--- a/src/ucs/debug/log_def.h
+++ b/src/ucs/debug/log_def.h
@@ -8,7 +8,7 @@
 #define UCS_LOG_DEF_H_
 
 #ifndef UCS_MAX_LOG_LEVEL
-#  define UCS_MAX_LOG_LEVEL  UCS_LOG_LEVEL_TRACE_LAST
+#  define UCS_MAX_LOG_LEVEL  UCS_LOG_LEVEL_LAST
 #endif
 
 #include <ucs/sys/compiler_def.h>


### PR DESCRIPTION
- there was undefined log level used in non-defined log level

(cherry picked from commit 82b45938b60edc2eb49fc64d45b90346431603f6)

backport from https://github.com/openucx/ucx/pull/7296