### PR TITLE
UCS/TIMERQ: fixed buffer release - int3

### DIFF
--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -114,7 +114,7 @@ ucs_status_t ucs_timerq_remove(ucs_timer_queue_t *timerq, int timer_id)
     /* TODO realloc - shrink */
     if (timerq->num_timers == 0) {
         ucs_assert(timerq->min_interval == UCS_TIME_INFINITY);
-        free(timerq->timers);
+        ucs_free(timerq->timers);
         timerq->timers = NULL;
     } else {
         ucs_assert(timerq->min_interval != UCS_TIME_INFINITY);


### PR DESCRIPTION
- there was unpaired malloc/free on timerq buffer
- fixed

(cherry picked from commit 6b499c9c362afd8ec9e1272509c8f5bec84031a0)

back port from https://github.com/openucx/ucx/pull/7344