### PR TITLE
IB/SEND-OPS/STR: added obj-str implementation

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -362,6 +362,7 @@ uct_rc_txqp_add_flush_comp(uct_rc_iface_t *iface, uct_base_ep_t *ep,
 
         op->flags     = 0;
         op->user_comp = comp;
+        uct_rc_iface_send_op_set_name(op, "rc_txqp_add_flush_comp");
         uct_rc_txqp_add_send_op_sn(txqp, op, sn);
         VALGRIND_MAKE_MEM_DEFINED(op, sizeof(*op)); /* handler set by mpool init */
     }

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -294,6 +294,9 @@ struct uct_rc_iface_send_op {
                                                   get_bcopy completions */
     };
     uct_completion_t              *user_comp;
+#if ENABLE_DEBUG_DATA
+    const char                    *name;       /* object ID, debug only */
+#endif
 };
 
 
@@ -473,4 +476,13 @@ uct_rc_iface_atomic_handler(uct_rc_iface_t *iface, int ext, unsigned length)
     }
     return NULL;
 }
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_send_op_set_name(uct_rc_iface_send_op_t *op, const char *name)
+{
+#if ENABLE_DEBUG_DATA
+    op->name = name;
+#endif
+}
+
 #endif


### PR DESCRIPTION
- added obj_str implementation for flush_mp mpool to simplify
  resource leaks investigation

backport from https://github.com/openucx/ucx/pull/7357