### PR TITLE
UCT/IB: Remove sighandlers in IB cleanup thread

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -68,6 +68,7 @@ BEGIN_C_DECLS
 
 /* revert to glibc syscall */
 #define ucs_syscall_raw               syscall
+#define ucs_syscall_raw4              syscall
 
 
 /*

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -41,6 +41,7 @@ BEGIN_C_DECLS
 
 /* revert to glibc syscall */
 #define ucs_syscall_raw               syscall
+#define ucs_syscall_raw4              syscall
 
 
 static inline uint64_t ucs_arch_read_hres_clock()

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -669,4 +669,22 @@ int ucs_syscall_raw(unsigned long num, unsigned long arg1, unsigned long arg2,
     return ret;
 }
 
+int ucs_syscall_raw4(unsigned long num, unsigned long arg1, unsigned long arg2,
+                     unsigned long arg3, unsigned long arg4)
+{
+    int ret;
+
+    asm volatile (
+        "movq %1, %%rax\n\t"
+        "movq %2, %%rdi\n\t"
+        "movq %3, %%rsi\n\t"
+        "movq %4, %%rdx\n\t"
+        "movq %5, %%r10\n\t"
+        "syscall\n\t"
+        :"=a"(ret)
+        :"r"(num), "r"(arg1), "r"(arg2), "r"(arg3), "r"(arg4));
+
+    return ret;
+}
+
 #endif

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -55,6 +55,8 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes);
 void ucs_x86_memcpy_sse_movntdqa(void *dst, const void *src, size_t len);
 int ucs_syscall_raw(unsigned long num, unsigned long arg1, unsigned long arg2,
                     unsigned long arg3);
+int ucs_syscall_raw4(unsigned long num, unsigned long arg1, unsigned long arg2,
+                     unsigned long arg3, unsigned long arg4);
 
 
 static inline int ucs_arch_x86_rdtsc_enabled()

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -416,19 +416,34 @@ ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
     return UCS_OK;
 }
 
+/* Based on include/linux/signal.h from kernel source */
+struct uct_ib_sigaction {
+    void     *uapi_sa_handler;
+    uint64_t uapi_sa_flags;
+    void     *uapi_sa_restorer;
+    uint64_t uapi_sa_mask;
+    uint64_t pad;   /* glibc compatibility */
+};
+
 static int uct_ib_device_cleanup_proc(void* arg)
 {
     uct_ib_device_nb_close_ctx *ctx = arg;
     static const char *process_name = "ucx_cleanup";
+    struct uct_ib_sigaction dfl     = { SIG_DFL };
     char dummy;
-    int fd;
+    int i;
+
+    for (i = 1; i <= SIGUSR2; i++) {
+        ucs_syscall_raw4(SYS_rt_sigaction, i, (long)&dfl, 0,
+                         sizeof(dfl.uapi_sa_mask));
+    }
 
     /* Since TLS of this thread is uninitialized avoid using glibc */
     ucs_syscall_raw(SYS_prctl, PR_SET_NAME, (long)process_name, 0);
 
-    for (fd = 0; fd < ctx->max_fds; fd++) {
-        if ((fd != ctx->cmd_fd) && (fd != ctx->pipefds[0])) {
-            ucs_syscall_raw(SYS_close, fd, 0, 0);
+    for (i = 0; i < ctx->max_fds; i++) {
+        if ((i != ctx->cmd_fd) && (i != ctx->pipefds[0])) {
+            ucs_syscall_raw(SYS_close, i, 0, 0);
         }
     }
 


### PR DESCRIPTION
## What 

Remove sighandlers in cleanup thread.

## Why?

We implement non-blocking IB close using special cleanup thread lacking libc support.
We creating this thread during IB initialization i.e. from ucp_worker_create().
IODEMO installing it's Ctrl-C handler during Demo constructor i.e. before creating cleanup thread which makes this thread inherit the handler.
Handler does logging which crashing in libc-less thread. 