### PR TITLE
discard unused uct_ep when the pre-created uct_ep more than needed

### DIFF
--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -35,6 +35,22 @@ parameters:
         interface: $(roce_iface_cx6)
         tls: "rc_x"
         test_name: tag_umemh_cx6_rc
+      "server one path compatible on CX4":
+        args: ""
+        initial_delay: 9999 # No interference
+        duration: 120
+        interface: $(roce_iface_cx4)
+        tls: "rc_x"
+        extra_run_args: "--env server UCX_IB_NUM_PATHS=1 --env client UCX_IB_NUM_PATHS=2"
+        test_name: tag_cx4_rc_server_one_path
+      "client one path compatible on CX4":
+        args: ""
+        initial_delay: 9999 # No interference
+        duration: 120
+        interface: $(roce_iface_cx4)
+        tls: "rc_x"
+        extra_run_args: "--env server UCX_IB_NUM_PATHS=2 --env client UCX_IB_NUM_PATHS=1"
+        test_name: tag_cx4_rc_client_one_path
 
 jobs:
   - job: io_build

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -154,7 +154,8 @@ unsigned ucp_ep_init_flags(const ucp_worker_h worker,
 ucs_status_t
 ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,
-                         const ucp_lane_index_t *lanes2remote,
-                         int *num_eps_connected_p);
+                         const ucp_lane_index_t *lanes2remote);
+
+void ucp_wireup_pending_purge_cb(uct_pending_req_t *self, void *arg);
 
 #endif


### PR DESCRIPTION
## What
keep NUM_PATHS compatible between server (e.g. UCX_IB_NUM_PATHS=1) and client (e.g. UCX_IB_NUM_PATHS=2)
This PR is mainly ported from:
1. https://github.com/openucx/ucx/pull/5608
2. https://github.com/openucx/ucx/pull/5696