### PR TITLE
UCP/CORE: Complete outstanding RNDV reqs after all UCT lanes are destroyed

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -824,6 +824,8 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         ep->uct_eps[lane] = NULL;
     }
+
+    ucp_ep_complete_rndv_reqs(ep);
 }
 
 static void ucp_worker_matchq_purge(ucp_tag_frag_match_t *matchq)
@@ -935,7 +937,6 @@ void ucp_ep_disconnected(ucp_ep_h ep, ucs_status_t status, int force)
     ucp_stream_ep_cleanup(ep, status);
     ucp_am_ep_cleanup(ep);
     ucp_ep_cleanup_unexp(ep);
-    ucp_ep_complete_rndv_reqs(ep);
 
     ep->flags &= ~UCP_EP_FLAG_USED;
 

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -490,7 +490,11 @@ void ucp_request_handle_send_error(ucp_request_t *req, ucs_status_t status)
         }
     } else {
         if (req->flags & UCP_REQUEST_FLAG_SEND_RNDV) {
-            ucp_rndv_complete_send(req, UCS_ERR_CANCELED, "rndv_flush");
+            if (req->flags & UCP_REQUEST_FLAG_RNDV_RTS_SENT) {
+                ucp_rndv_req_add_to_cancelled_list(req, status);
+            } else {
+                ucp_rndv_complete_send(req, status, "rndv_flush");
+            }
        } else {
             ucp_request_complete_send(req, status);
         }

--- a/src/ucp/tag/rndv.h
+++ b/src/ucp/tag/rndv.h
@@ -65,6 +65,9 @@ ucs_status_t ucp_rndv_process_rts(void *arg, void *data, size_t length,
 
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
 
+void ucp_rndv_req_add_to_cancelled_list(ucp_request_t *sreq,
+                                        ucs_status_t status);
+
 ucs_status_t ucp_tag_rndv_reg_send_buffer(ucp_request_t *sreq);
 
 void ucp_ep_complete_rndv_reqs(ucp_ep_h ep);


### PR DESCRIPTION
Fixes:
```
Error iodemo analyzer: [1638101311.245289] [DEMO] ERROR: iov data corruption (0x7f15fecfb800: expected: segment=9700 conn_id=4 seed=c13f6b8 got: segment=9700 conn_id=ffff seed=ffffffff) at 309248 position detected on [UCX-connection 0x1cc9cb0: #6 1.1.27.4:59736] (status=Success) for operation (length=316907 op="write")
```
found by [NVDA/MLNX MTT (internal link)](http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20211128_071700_37445_82883_swx-ucx03.swx.labs.mlnx/html/test_stdout_NyNQfE.txt)