### PR TITLE
UCP/EP: support selecting local address

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -227,7 +227,8 @@ enum ucp_ep_params_field {
     UCP_EP_PARAM_FIELD_USER_DATA         = UCS_BIT(3), /**< User data pointer */
     UCP_EP_PARAM_FIELD_SOCK_ADDR         = UCS_BIT(4), /**< Socket address field */
     UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(5), /**< Endpoint flags */
-    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6)  /**< Connection request field */
+    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6), /**< Connection request field */
+    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(7)  /**< Local socket Address */
 };
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -623,6 +623,15 @@ typedef struct ucp_ep_params {
      */
     ucp_conn_request_h      conn_request;
 
+    /**
+     * The sockaddr to bind locally. Specifies the associated network device
+     * to bind locally to establish new connections.
+     * To retrieve the endpoint's local_sockaddr, use @ref ucp_ep_query.
+     * This setting is optional. To enable it, the corresponding - @ref
+     * UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR bit in the field mask must be set.
+     */
+    ucs_sock_addr_t         local_sockaddr;
+
 } ucp_ep_params_t;
 
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -501,6 +501,12 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
     cm_lane_params.sockaddr_pack_cb           = ucp_cm_client_priv_pack_cb;
     cm_lane_params.sockaddr_connect_cb.client = ucp_cm_client_connect_cb;
     cm_lane_params.disconnect_cb              = ucp_cm_disconnect_cb;
+
+    if (params->field_mask & UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR) {
+        cm_lane_params.field_mask            |= UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR;
+        cm_lane_params.local_sockaddr         = &params->local_sockaddr;
+    }
+
     ucs_assert_always(ucp_worker_num_cm_cmpts(worker) == 1);
     cm_lane_params.cm                         = worker->cms[0].cm;
 

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -389,6 +389,20 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 
 /**
+ * Extract the IP address from a given string and return it as a sockaddr storage.
+ *
+ * @param [in]  ip_str       A string to take IP address from.
+ * @param [out] sa_storage   sockaddr storage filled with the IP address and
+ *                           address family.
+ *
+ * @return UCS_OK if @a ip_str has a valid IP address or UCS_ERR_INVALID_ADDR
+ *         otherwise.
+ */
+ucs_status_t ucs_sock_ipstr_to_sockaddr(const char *ip_str,
+                                        struct sockaddr_storage *sa_storage);
+
+
+/**
  * Check if the address family of the given sockaddr is IPv4 or IPv6
  *
  * @param [in] sa       Pointer to sockaddr structure.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -798,7 +798,11 @@ enum uct_ep_params_field {
     UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB = UCS_BIT(10),
 
     /** Enables @ref uct_ep_params::path_index */
-    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11)
+    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11),
+
+    /** Enables @ref uct_ep_params::local_sockaddr */
+    UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR         = UCS_BIT(12)
+
 };
 
 
@@ -1130,6 +1134,14 @@ struct uct_ep_params {
      * 0..(@ref uct_iface_attr_t.dev_num_paths - 1).
      */
     unsigned                            path_index;
+
+    /**
+     * The sockaddr to bind locally. If set, @ref uct_ep_create
+     * will create an endpoint binding to this local sockaddr.
+     * @note The interface in this routine requires the
+     * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
+     */
+    const ucs_sock_addr_t             *local_sockaddr;
 };
 
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -604,9 +604,46 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_is_reachable       = (uct_iface_is_reachable_func_t)ucs_empty_function_return_zero
 };
 
+static ucs_status_t
+uct_rdmacm_cm_ipstr_to_sockaddr(const char *ip_str, struct sockaddr **saddr_p,
+                                const char *debug_name)
+{
+    struct sockaddr_storage *sa_storage;
+    ucs_status_t status;
+
+    /* NULL-pointer for empty parameter */
+    if (ip_str[0] == '\0') {
+        sa_storage = NULL;
+        goto out;
+    }
+
+    sa_storage = ucs_calloc(1, sizeof(struct sockaddr_storage), debug_name);
+    if (sa_storage == NULL) {
+        ucs_error("cannot allocate memory for rdmacm source address");
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    status = ucs_sock_ipstr_to_sockaddr(ip_str, sa_storage);
+    if (status != UCS_OK) {
+        goto err_free;
+    }
+
+out:
+    *saddr_p = (struct sockaddr*)sa_storage;
+    return UCS_OK;
+
+err_free:
+    ucs_free(sa_storage);
+err:
+    return status;
+}
+
 UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
                     uct_worker_h worker, const uct_cm_config_t *config)
 {
+    const uct_rdmacm_cm_config_t *rdmacm_config = ucs_derived_of(config,
+                                                                 uct_rdmacm_cm_config_t);
     uct_priv_worker_t *worker_priv;
     ucs_status_t status;
 
@@ -640,11 +677,20 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
         goto err_destroy_ev_ch;
     }
 
+    status = uct_rdmacm_cm_ipstr_to_sockaddr(rdmacm_config->src_addr,
+                                             &self->config.src_addr,
+                                             "rdmacm_src_addr");
+    if (status != UCS_OK) {
+        goto ucs_async_remove_handler;
+    }
+
     ucs_debug("created rdmacm_cm %p with event_channel %p (fd=%d)",
               self, self->ev_ch, self->ev_ch->fd);
 
     return UCS_OK;
 
+ucs_async_remove_handler:
+    ucs_async_remove_handler(self->ev_ch->fd, 1);
 err_destroy_ev_ch:
     rdma_destroy_event_channel(self->ev_ch);
 err:
@@ -654,6 +700,8 @@ err:
 UCS_CLASS_CLEANUP_FUNC(uct_rdmacm_cm_t)
 {
     ucs_status_t status;
+
+    ucs_free(self->config.src_addr);
 
     status = ucs_async_remove_handler(self->ev_ch->fd, 1);
     if (status != UCS_OK) {

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -23,7 +23,17 @@ typedef struct uct_rdmacm_cm {
     uct_cm_t                   super;
     struct rdma_event_channel  *ev_ch;
     khash_t(uct_rdmacm_cm_cqs) cqs;
+
+    struct {
+        struct sockaddr        *src_addr;
+    } config;
 } uct_rdmacm_cm_t;
+
+
+typedef struct uct_rdmacm_cm_config {
+    uct_cm_config_t            super;
+    char                       *src_addr;
+} uct_rdmacm_cm_config_t;
 
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rdmacm_cm_t, uct_cm_t, uct_component_h,

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -259,9 +259,11 @@ static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,
                                                  const uct_ep_params_t *params)
 {
     uct_rdmacm_cm_t *rdmacm_cm = uct_rdmacm_cm_ep_get_cm(cep);
-    char ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char src_ip_port_str[UCS_SOCKADDR_STRING_LEN];
+    char dst_ip_port_str[UCS_SOCKADDR_STRING_LEN];
     char ep_str[UCT_RDMACM_EP_STRING_LEN];
     ucs_status_t status;
+    struct sockaddr *src_addr;
 
     cep->flags |= UCT_RDMACM_CM_EP_ON_CLIENT;
     cep->super.client.connect_cb = params->sockaddr_connect_cb.client;
@@ -283,11 +285,18 @@ static ucs_status_t uct_rdamcm_cm_ep_client_init(uct_rdmacm_cm_ep_t *cep,
      * function is called. */
     ucs_trace("%s: rdma_resolve_addr on cm_id %p",
               uct_rdmacm_cm_ep_str(cep, ep_str, UCT_RDMACM_EP_STRING_LEN), cep->id);
-    if (rdma_resolve_addr(cep->id, NULL, (struct sockaddr *)params->sockaddr->addr,
+    src_addr = (params->field_mask & UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR) ?
+               (struct sockaddr*)params->local_sockaddr->addr :
+               rdmacm_cm->config.src_addr;
+    if (rdma_resolve_addr(cep->id, src_addr,
+                          (struct sockaddr *)params->sockaddr->addr,
                           uct_rdmacm_cm_get_timeout(rdmacm_cm))) {
-        ucs_error("rdma_resolve_addr() to dst addr %s failed: %m",
-                  ucs_sockaddr_str((struct sockaddr *)params->sockaddr->addr,
-                                   ip_port_str, UCS_SOCKADDR_STRING_LEN));
+        ucs_diag("rdma_resolve_addr(src=%s, dst=%s) failed (%d): %m",
+                 ucs_sockaddr_str(src_addr,
+                                  src_ip_port_str, UCS_SOCKADDR_STRING_LEN),
+                 ucs_sockaddr_str((struct sockaddr*)params->sockaddr->addr,
+                                  dst_ip_port_str, UCS_SOCKADDR_STRING_LEN),
+                 errno);
         status = UCS_ERR_IO_ERROR;
         goto err_destroy_id;
     }

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -23,6 +23,18 @@ static ucs_config_field_t uct_rdmacm_md_config_table[] = {
   {NULL}
 };
 
+static ucs_config_field_t uct_rdmacm_cm_config_table[] = {
+    {"CM_", "", NULL,
+     ucs_offsetof(uct_rdmacm_cm_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_cm_config_table)},
+
+    {"SOURCE_ADDRESS", "",
+     "If non-empty, specify the local source address (IPv4 or IPv6) to use\n"
+     "when creating a client connection",
+     ucs_offsetof(uct_rdmacm_cm_config_t, src_addr), UCS_CONFIG_TYPE_STRING},
+
+    {NULL}
+};
+
 static void uct_rdmacm_md_close(uct_md_h md);
 
 static uct_md_ops_t uct_rdmacm_md_ops = {
@@ -252,9 +264,9 @@ uct_component_t uct_rdmacm_component = {
     },
     .cm_config          = {
         .name           = "RDMA-CM connection manager",
-        .prefix         = "RDMACM_",
-        .table          = uct_cm_config_table,
-        .size           = sizeof(uct_cm_config_t),
+        .prefix         = "RDMA_CM_",
+        .table          = uct_rdmacm_cm_config_table,
+        .size           = sizeof(uct_rdmacm_cm_config_t),
     },
     .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_rdmacm_component),
 #if HAVE_RDMACM_QP_LESS

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -80,6 +80,7 @@ typedef struct {
     bool                     debug_timeout;
     size_t                   rndv_thresh;
     unsigned                 progress_count;
+    const char*              src_addr;
 } options_t;
 
 #define LOG_PREFIX  "[DEMO]"
@@ -1538,15 +1539,35 @@ public:
         }
     }
 
+    bool set_sockaddr(const std::string &ip_str, uint16_t port,
+                      struct sockaddr *saddr)
+    {
+        struct sockaddr_in* sa_in = (struct sockaddr_in*)saddr;
+        if (inet_pton(AF_INET, ip_str.c_str(), &sa_in->sin_addr) == 1) {
+            sa_in->sin_family = AF_INET;
+            sa_in->sin_port   = htons(port);
+            return true;
+        }
+
+        struct sockaddr_in6* sa_in6 = (struct sockaddr_in6*)saddr;
+        if (inet_pton(AF_INET6, ip_str.c_str(), &sa_in6->sin6_addr) == 1) {
+            sa_in6->sin6_family = AF_INET6;
+            sa_in6->sin6_port   = htons(port);
+            return true;
+        }
+
+        std::cout << "invalid address '" << ip_str << "'" << std::endl;
+        return false;
+    }
+
     void connect(size_t server_index)
     {
         const char *server = opts().servers[server_index];
-        struct sockaddr_in connect_addr;
+        struct sockaddr_storage *src_addr_p = NULL;
+        struct sockaddr_storage dst_addr, src_addr;
         std::string server_addr;
         int port_num;
-
-        memset(&connect_addr, 0, sizeof(connect_addr));
-        connect_addr.sin_family = AF_INET;
+        bool ret;
 
         const char *port_separator = strchr(server, ':');
         if (port_separator == NULL) {
@@ -1560,11 +1581,18 @@ public:
             port_num    = atoi(port_separator + 1);
         }
 
-        connect_addr.sin_port = htons(port_num);
-        int ret = inet_pton(AF_INET, server_addr.c_str(), &connect_addr.sin_addr);
-        if (ret != 1) {
-            LOG << "invalid address " << server_addr;
+        ret = set_sockaddr(server_addr, port_num, (struct sockaddr*)&dst_addr);
+        if (ret != true) {
             abort();
+        }
+
+        if (opts().src_addr != NULL) {
+            ret = set_sockaddr(opts().src_addr, 0, (struct sockaddr*)&src_addr);
+            if (ret != true) {
+                abort();
+            }
+
+            src_addr_p = &src_addr;
         }
 
         if (!_connecting_servers.insert(server_index).second) {
@@ -1574,8 +1602,9 @@ public:
 
         UcxConnection *conn = new UcxConnection(*this);
         _server_info[server_index].conn = conn;
-        conn->connect((const struct sockaddr*)&connect_addr,
-                      sizeof(connect_addr),
+        conn->connect((const struct sockaddr*)src_addr_p,
+                      (const struct sockaddr*)&dst_addr,
+                      sizeof(dst_addr),
                       new ConnectCallback(*this, server_index));
     }
 
@@ -2124,9 +2153,10 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
     test_opts->debug_timeout         = false;
     test_opts->rndv_thresh           = UcxContext::rndv_thresh_auto;
     test_opts->progress_count        = 1;
+    test_opts->src_addr              = NULL;
 
     while ((c = getopt(argc, argv,
-                       "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqDHP:L:R:C:")) != -1) {
+                       "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqDHP:L:R:C:I:")) != -1) {
         switch (c) {
         case 'p':
             test_opts->port_num = atoi(optarg);
@@ -2256,6 +2286,9 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
         case 'R':
             test_opts->rndv_thresh = strtol(optarg, NULL, 0);
             break;
+        case 'I':
+            test_opts->src_addr = optarg;
+            break;
         case 'h':
         default:
             std::cout << "Usage: io_demo [options] [server_address]" << std::endl;
@@ -2292,6 +2325,7 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
             std::cout << "  -R <rndv-thresh>           Rendezvous threshold used to force eager or rendezvous protocol";
             std::cout << "" << std::endl;
             std::cout << "  -C <progress_count>        Maximal number of consecutive ucp_worker_progress invocations" << std::endl;
+            std::cout << "  -I <src_addr>              Set source IP address to select network interface on client side" << std::endl;
             return -1;
         }
     }

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -693,21 +693,28 @@ UcxConnection::~UcxConnection()
     --_num_instances;
 }
 
-void UcxConnection::connect(const struct sockaddr *saddr, socklen_t addrlen,
+void UcxConnection::connect(const struct sockaddr *src_saddr,
+                            const struct sockaddr *dst_saddr,
+                            socklen_t addrlen,
                             UcxCallback *callback)
 {
-    set_log_prefix(saddr, addrlen);
+    set_log_prefix(dst_saddr, addrlen);
 
     ucp_ep_params_t ep_params;
     ep_params.field_mask       = UCP_EP_PARAM_FIELD_FLAGS |
                                  UCP_EP_PARAM_FIELD_SOCK_ADDR;
     ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-    ep_params.sockaddr.addr    = saddr;
+    ep_params.sockaddr.addr    = dst_saddr;
     ep_params.sockaddr.addrlen = addrlen;
+    if (src_saddr != NULL) {
+        ep_params.field_mask            |= UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR;
+        ep_params.local_sockaddr.addr    = src_saddr;
+        ep_params.local_sockaddr.addrlen = addrlen;
+    }
 
     char sockaddr_str[UCS_SOCKADDR_STRING_LEN];
     UCX_CONN_LOG << "Connecting to "
-                 << ucs_sockaddr_str(saddr, sockaddr_str,
+                 << ucs_sockaddr_str(dst_saddr, sockaddr_str,
                                      UCS_SOCKADDR_STRING_LEN);
     connect_common(ep_params, callback);
 }

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -259,7 +259,9 @@ public:
 
     ~UcxConnection();
 
-    void connect(const struct sockaddr *saddr, socklen_t addrlen,
+    void connect(const struct sockaddr *src_saddr,
+                 const struct sockaddr *dst_saddr,
+                 socklen_t addrlen,
                  UcxCallback *callback);
 
     void accept(ucp_conn_request_h conn_req, UcxCallback *callback);


### PR DESCRIPTION
Why ?
if users have multiple HCAs on client side, they can select the NIC they want to use (round robin fashion for example)
backport #7623

What ?
support selecting local address for each connection

How ?
two methods
1.specify local address in ucp_ep_params when call ucp_ep_create() for each connection
2.use env variable UCX_RDMA_CM_SOURCE_ADDRESS to select NIC for all connections