### PR TITLE
UCP/TAG/RNDV: Complete send operation only if RTS wasn't sent

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -421,6 +421,8 @@ void ucp_tag_rndv_cancel(ucp_request_t *sreq)
 {
     if (!(sreq->send.ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
         if (sreq->flags & UCP_REQUEST_FLAG_RNDV_RTS_SENT) {
+            ucp_rndv_req_add_to_cancelled_list(sreq, UCS_ERR_CANCELED);
+        } else {
             ucp_rndv_complete_send(sreq, UCS_ERR_CANCELED, "rndv_cancel");
         }
     } else {


### PR DESCRIPTION
Fixes:
```
Error iodemo analyzer: [1640029744.908498] [DEMO] ERROR: iov data corruption (0x7f7087be9800: expected: segment=ed00 conn_id=10 seed=3c212088 got: segment=ed00 conn_id=ffff seed=ffffffff) at 485376 position detected on [UCX-connection 0x99dd10: #16 2.1.3.7:20011] (status=Endpoint is not connected) for operation (length=487269 mem_type=0 op="read")
```
http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20211220_211114_26976_84801_jazz07.swx.labs.mlnx/html/test_stdout_w5cd6S.txt

UCP RNDV request should be completed during the request cancellation procedure only if the RTS packet wasn't sent to the peer (i.e. the peer is not aware of this operation). If the RTS packet was sent we should put the request on the list of canceled requests and it will be cleaned when all UCT lanes are destroyed and UCP EP is under destroying.