### PR TITLE
UCP/RNDV: Don't complete operation from CANCEL if RTS wasn't sent

### DIFF
--- a/src/ucp/tag/rndv.c
+++ b/src/ucp/tag/rndv.c
@@ -420,10 +420,10 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
 void ucp_tag_rndv_cancel(ucp_request_t *sreq)
 {
     if (!(sreq->send.ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
+        /* If RTS wasn't sent, it is still on the pending queue and the request
+         * will be completed from the purge callback */
         if (sreq->flags & UCP_REQUEST_FLAG_RNDV_RTS_SENT) {
             ucp_rndv_req_add_to_cancelled_list(sreq, UCS_ERR_CANCELED);
-        } else {
-            ucp_rndv_complete_send(sreq, UCS_ERR_CANCELED, "rndv_cancel");
         }
     } else {
         sreq->send.uct.func = ucp_proto_progress_rndv_cancel;


### PR DESCRIPTION
Fixes: http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220109_125149_188193_86219_jazz02.swx.labs.mlnx/html/test_stdout_BJNZGm.txt