### PR TITLE
CI/IODEMO: use configure-devel

### DIFF
--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -43,7 +43,7 @@ jobs:
       - bash: |
           set -eEx
           ./autogen.sh
-          ./contrib/configure-release --prefix=$(Build.Repository.LocalPath)/install
+          ./contrib/configure-devel --prefix=$(Build.Repository.LocalPath)/install
           make -j`nproc`
           make install
         displayName: Build


### PR DESCRIPTION
use configure-devel config to trigger assertions in testing