### PR TITLE
UCP/TAG/TEST: Implement ucp_tag_recv_nbx()

### DIFF
--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -23,6 +23,12 @@ parameters:
         interface: $(roce_iface_cx4)
         tls: "rc_x"
         test_name: tag_cx4_rc
+      "tag match on CX6":
+        args: ""
+        duration: 600
+        interface: $(roce_iface_cx6)
+        tls: "rc_x"
+        test_name: tag_cx6_rc
 
 jobs:
   - job: io_build

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -5,6 +5,11 @@ resources:
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
 
 stages:
+  - stage: test
+    jobs:
+    - template: test.yml
+
   - stage: io_demo
     jobs:
     - template: io_demo/io-demo.yml
+    dependsOn: []

--- a/buildlib/pr/test.yml
+++ b/buildlib/pr/test.yml
@@ -1,0 +1,47 @@
+jobs:
+  - job: test
+    displayName: Test on RoCE
+
+    pool:
+      name: MLNX
+      demands: ucx_roce -equals yes
+
+    steps:
+      - checkout: self
+        clean: true
+
+      - bash: |
+          set -eEx
+          ./autogen.sh
+          ./contrib/configure-devel --prefix=$(pwd)/install
+          make -j`nproc` install
+        name: build
+
+      - bash: |
+          set -eEx
+          ibv_devinfo -v
+
+          # Test on all active devices
+          count=0
+          for ibdev in $(ls /sys/class/infiniband)
+          do
+            port=1
+            ibv_devinfo -d ${ibdev} -i ${port} | grep 'PORT_ACTIVE' || continue
+
+            export GTEST_FILTER='rcx/test_ucp_tag_nbx*'
+            export UCX_NET_DEVICES="${ibdev}:${port}"
+
+            # Run the test
+            make -C test/gtest test
+
+            # Run the test with valgrind
+            make -C test/gtest test_valgrind
+
+            count=$((count+1))
+          done
+
+          if [ ${count} -eq 0 ]; then
+            echo "No active devices found"
+            exit 1
+          fi
+        name: gtest

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -280,7 +280,7 @@ struct ucp_request {
                     ucp_tag_t               tag;      /* Expected tag */
                     ucp_tag_t               tag_mask; /* Expected tag mask */
                     uint64_t                sn;       /* Tag match sequence */
-                    ucp_tag_recv_callback_t cb;       /* Completion callback */
+                    ucp_tag_recv_nbx_callback_t cb;   /* Completion callback */
                     ucp_tag_recv_info_t     info;     /* Completion info to fill */
                     ssize_t                 remaining; /* How much more data to be received */
 

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -366,8 +366,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
 
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {
         cb             = param->cb.send;
-        req->user_data = param->op_attr_mask & UCP_OP_ATTR_FIELD_USER_DATA ?
-                         param->user_data : NULL;
+        req->user_data = ucp_request_param_user_data(param);
     } else {
         cb = NULL;
     }


### PR DESCRIPTION
## Why
In order to support user-provided memory handle for tag-receive operations

## How
- Port relevant code from master branch
- Add gtest and run it in CI