### PR TITLE
UCT/TCP/RDMACM: Fix CM common config inheritance and restore the original name of RDMACM configs

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -24,7 +24,7 @@ static ucs_config_field_t uct_rdmacm_md_config_table[] = {
 };
 
 static ucs_config_field_t uct_rdmacm_cm_config_table[] = {
-    {"CM_", "", NULL,
+    {"", "", NULL,
      ucs_offsetof(uct_rdmacm_cm_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_cm_config_table)},
 
     {"SOURCE_ADDRESS", "",
@@ -264,7 +264,7 @@ uct_component_t uct_rdmacm_component = {
     },
     .cm_config          = {
         .name           = "RDMA-CM connection manager",
-        .prefix         = "RDMA_CM_",
+        .prefix         = "RDMACM_",
         .table          = uct_rdmacm_cm_config_table,
         .size           = sizeof(uct_rdmacm_cm_config_t),
     },

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -15,7 +15,7 @@
 
 
 ucs_config_field_t uct_tcp_sockcm_config_table[] = {
-  {"TCP_", "", NULL,
+  {"", "", NULL,
    ucs_offsetof(uct_tcp_sockcm_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_cm_config_table)},
 
   {"PRIV_DATA_LEN", "2048",


### PR DESCRIPTION
1. Fixes [RDMACM failures in MTT/io-demo](http://hpcweb.lab.mtl.com//hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_041212_29793_999_swx-ucx05.swx.labs.mlnx/html/test_stdout_xBYabK.txt) - happens after merging https://github.com/yosefe/ucx/pull/229
The name was changed to the original one to not introduce non-backward-compatible change.
Before (changed name from RDMACM to RDMA_CM):
```
$./install/int3/bin/ucx_info -cfa | grep -i ALLOW_ADDR_INUSE | grep -i RDMA
UCX_RDMA_CM_ALLOW_ADDR_INUSE=n
```
After (no changes in RDMACM configuration name):

```
$./install/int3/bin/ucx_info -cfa | grep -i ALLOW_ADDR_INUSE | grep -i RDMA
UCX_RDMACM_ALLOW_ADDR_INUSE=n
```
2. Fixes inheritance of CM common config in TCP_CM and RDMACM.
Before (can't change config using the common name UCX_ALLOW_ADDR_INUSE):
```
$UCX_ALLOW_ADDR_INUSE=y ./install/int3/bin/ucx_info -cfa | grep -i ALLOW_ADDR_INUSE
UCX_TCP_ALLOW_ADDR_INUSE=n
# inherits:  UCX_CM_ALLOW_ADDR_INUSE
UCX_RDMA_CM_ALLOW_ADDR_INUSE=n
```
After (can change config using the common name UCX_ALLOW_ADDR_INUSE):

```
$UCX_ALLOW_ADDR_INUSE=y ./install/int3/bin/ucx_info -cfa | grep -i ALLOW_ADDR_INUSE
# inherits:  UCX_ALLOW_ADDR_INUSE
UCX_TCP_ALLOW_ADDR_INUSE=y
# inherits:  UCX_ALLOW_ADDR_INUSE
UCX_RDMACM_ALLOW_ADDR_INUSE=y
```